### PR TITLE
feat: create core-encryption secret only if encryption.existingSecret is not set

### DIFF
--- a/charts/dial-core/Chart.yaml
+++ b/charts/dial-core/Chart.yaml
@@ -26,4 +26,4 @@ maintainers:
 name: dial-core
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial-core
-version: 2.0.2
+version: 2.0.3

--- a/charts/dial-core/README.md
+++ b/charts/dial-core/README.md
@@ -1,6 +1,6 @@
 # dial-core
 
-![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 2.0.3](https://img.shields.io/badge/Version-2.0.3-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Helm chart for dial core
 

--- a/charts/dial-core/templates/secret-encryption.yaml
+++ b/charts/dial-core/templates/secret-encryption.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.configuration.encryption.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -23,3 +24,4 @@ type: Opaque
 data:
   aidial.encryption.password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "dialCore.encryptionSecretName" .) "key" "aidial.encryption.password" "providedValues" (list "configuration.encryption.password") "length" 32 "strong" false "context" $) }}
   aidial.encryption.salt: {{ include "common.secrets.passwords.manage" (dict "secret" (include "dialCore.encryptionSecretName" .) "key" "aidial.encryption.salt" "providedValues" (list "configuration.encryption.salt") "length" 32 "strong" false "context" $) }}
+{{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of DIAL might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Applicable issues

### Description of changes

Create `core-encryption` secret only if `encryption.existingSecret` is not set

### Additional information

### Testing

Tested manually

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/)
- [ ] `appVersion` bumped in `Chart.yaml` if it's `dial` chart and any application version changed
- [x] Variables are documented in the `values.yaml` and added to the `README.md` using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
