### PR TITLE
fix: core_encryption_salt placeholder

### DIFF
--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -11,7 +11,7 @@ core:
   configuration:
     encryption:
       password: "%%CORE_ENCRYPT_PASSWORD%%"
-      salt: "%CORE_ENCRYPT_SALT%"
+      salt: "%%CORE_ENCRYPT_SALT%%"
   env:
     aidial.config.files: '["/mnt/secrets-store/aidial.config.json"]'
     aidial.storage.provider: "aws-s3"

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -12,7 +12,7 @@ core:
   configuration:
     encryption:
       password: "%%CORE_ENCRYPT_PASSWORD%%"
-      salt: "%CORE_ENCRYPT_SALT%"
+      salt: "%%CORE_ENCRYPT_SALT%%"
   env:
     aidial.config.files: '["/mnt/secrets-store/aidial.config.json"]'
     aidial.storage.provider: "azureblob"

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -10,7 +10,7 @@ core:
   configuration:
     encryption:
       password: "%%CORE_ENCRYPT_PASSWORD%%"
-      salt: "%CORE_ENCRYPT_SALT%"
+      salt: "%%CORE_ENCRYPT_SALT%%"
   env:
     aidial.config.files: '["/mnt/secrets-store/aidial.config.json"]'
     aidial.storage.provider: "google-cloud-storage"

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -6,7 +6,7 @@ core:
   configuration:
     encryption:
       password: "%%CORE_ENCRYPT_PASSWORD%%"
-      salt: "%CORE_ENCRYPT_SALT%"
+      salt: "%%CORE_ENCRYPT_SALT%%"
   env:
     aidial.config.files: '["/mnt/secrets-store/aidial.config.json"]'
     aidial.identityProviders.fake.jwksUrl: "http://fakeJwksUrl"


### PR DESCRIPTION
### Description of changes

Fixed minor inconvenience during installation. README files mention `%%CORE_ENCRYPT_SALT%%` substitution but actual values file contain `%CORE_ENCRYPT_SALT%`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
