### PR TITLE
feat!: core encryption configuration changes in dial chart

### DIFF
--- a/charts/dial/Chart.yaml
+++ b/charts/dial/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
     repository: https://charts.epam-rail.com
     alias: core
     condition: core.enabled
-    version: 2.0.5
+    version: 3.0.0
   - name: dial-extension
     repository: https://charts.epam-rail.com
     alias: chat

--- a/charts/dial/Chart.yaml
+++ b/charts/dial/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: MachineLearning
   licenses: Apache-2.0
 apiVersion: v2
-appVersion: "1.14.0"
+appVersion: "1.14.1"
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -65,4 +65,4 @@ maintainers:
 name: dial
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial
-version: 2.9.0
+version: 3.0.0

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -18,7 +18,7 @@ Kubernetes: `>=1.23.0-0`
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | common | 2.14.1 |
 | https://charts.bitnami.com/bitnami | keycloak | 16.1.7 |
-| https://charts.epam-rail.com | core(dial-core) | 2.0.5 |
+| https://charts.epam-rail.com | core(dial-core) | 3.0.0 |
 | https://charts.epam-rail.com | authhelper(dial-extension) | 1.0.4 |
 | https://charts.epam-rail.com | chat(dial-extension) | 1.0.4 |
 | https://charts.epam-rail.com | themes(dial-extension) | 1.0.4 |

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -20,7 +20,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 helm repo add dial https://charts.epam-rail.com
-helm install --name my-release dial/dial
+helm install my-release dial/dial
 ```
 
 The command deploys AI DIAL on the Kubernetes cluster with default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -66,3 +66,50 @@ helm install my-release dial/dial -f values.yaml
 **NOTE**: You can use the default [values.yaml](values.yaml)
 
 {{ template "chart.valuesSection" . }}
+
+## Upgrading
+
+### To 3.0.0
+
+In this version we have to reflect `ai-dial-core` [application configuration parameters renaming](https://github.com/epam/ai-dial-core/pull/455) in version `0.15.1+` by renaming several values in this chart.
+
+- `core.configuration.encryption.password` parameter is renamed to `core.configuration.encryption.secret`
+- `core.configuration.encryption.salt` parameter is changed to `core.configuration.encryption.key`
+
+### How to upgrade to version 3.0.0
+
+a) If using encryption Kubernetes secret created by the chart:
+
+1. Update the parameters you have in your current deployment values (e.g. `values.yaml` file or set via `--set`) according to the changes below:
+     - `core.configuration.encryption.password` --> `core.configuration.encryption.secret`
+     - `core.configuration.encryption.salt` --> `core.configuration.encryption.key`
+1. Delete the `*-encryption` secret, e.g. (replace `my-release` with the actual release name):
+
+    ```console
+    kubectl delete secret my-release-dial-core-encryption
+    ```
+
+1. Proceed with the helm upgrade as usual, e.g.:
+
+    ```console
+    helm upgrade my-release dial/dial -f values.yaml
+    ```
+
+b) If using your own managed Kubernetes secret (`core.configuration.encryption.existingSecret` is set):
+
+1. Rename keys in your existing secret:
+
+    - `aidial.encryption.password` --> `aidial.encryption.secret`
+    - `aidial.encryption.salt` --> `aidial.encryption.key`
+
+    You can update your existing secret to rename or move the keys using the following one-liner command (replace `<your-existing-secret-name>` and `<namespace>` with the actual values):
+
+    ```console
+      kubectl get secret <your-existing-secret-name> -o yaml -n <namespace> | jq '.data["aidial.encryption.secret"] = .data["aidial.encryption.password"] | .data["aidial.encryption.key"] = .data["aidial.encryption.salt"] | del(.data["aidial.encryption.password"], .data["aidial.encryption.salt"])' | kubectl replace -f -
+    ```
+
+1. Proceed with the helm upgrade as usual, e.g.:
+
+    ```console
+    helm upgrade my-release dial/dial -f values.yaml
+    ```

--- a/charts/dial/examples/aws/complete/README.md
+++ b/charts/dial/examples/aws/complete/README.md
@@ -98,8 +98,8 @@ For authenticaConfiguring authentication provider, encrypted secrets, model usag
     - Replace `%%NAMESPACE%%` with namespace created above, e.g. `dial`
     - Replace `%%DOMAIN%%` with your domain name, e.g. `example.com`
     - Replace `%%DIAL_API_KEY%%` with generated value (`pwgen -s -1 64`)
-    - Replace `%%CORE_ENCRYPT_PASSWORD%%` with generated value (`pwgen -s -1 32`)
-    - Replace `%%CORE_ENCRYPT_SALT%%` with generated value (`pwgen -s -1 32`)
+    - Replace `%%CORE_ENCRYPT_SECRET%%` with generated value (`pwgen -s -1 32`)
+    - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%AWS_CORE_ROLE_ARN%%` with S3 AWS role ARN from [prerequisites](#prerequisites)
     - Replace `%%AWS_CORE_S3_BUCKET_NAME%%` with S3 bucket name from [prerequisites](#prerequisites)

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -7,8 +7,8 @@ core:
       eks.amazonaws.com/role-arn: "%%AWS_CORE_ROLE_ARN%%"
   configuration:
     encryption:
-      password: "%%CORE_ENCRYPT_PASSWORD%%"
-      salt: "%%CORE_ENCRYPT_SALT%%"
+      secret: "%%CORE_ENCRYPT_SECRET%%"
+      key: "%%CORE_ENCRYPT_KEY%%"
   env:
     aidial.config.files: '["/mnt/secrets-store/aidial.config.json"]'
     aidial.storage.provider: "aws-s3"

--- a/charts/dial/examples/aws/simple/README.md
+++ b/charts/dial/examples/aws/simple/README.md
@@ -59,8 +59,8 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%NAMESPACE%%` with namespace created above, e.g. `dial`
     - Replace `%%DOMAIN%%` with your domain name, e.g. `example.com`
     - Replace `%%DIAL_API_KEY%%` with generated value (`pwgen -s -1 64`)
-    - Replace `%%CORE_ENCRYPT_PASSWORD%%` with generated value (`pwgen -s -1 32`)
-    - Replace `%%CORE_ENCRYPT_SALT%%` with generated value (`pwgen -s -1 32`)
+    - Replace `%%CORE_ENCRYPT_SECRET%%` with generated value (`pwgen -s -1 32`)
+    - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%AWS_CORE_ROLE_ARN%%` with S3 AWS role ARN from [prerequisites](#prerequisites)

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -10,8 +10,8 @@ core:
     autorestart: '{{ dateInZone "2006-01-02 15:04:05Z" (now) "UTC" }}'
   configuration:
     encryption:
-      password: "%%CORE_ENCRYPT_PASSWORD%%"
-      salt: "%CORE_ENCRYPT_SALT%"
+      secret: "%%CORE_ENCRYPT_SECRET%%"
+      key: "%CORE_ENCRYPT_KEY%"
   env:
     aidial.config.files: '["/mnt/secrets-store/aidial.config.json"]'
     aidial.storage.provider: "aws-s3"

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -11,7 +11,7 @@ core:
   configuration:
     encryption:
       secret: "%%CORE_ENCRYPT_SECRET%%"
-      key: "%CORE_ENCRYPT_KEY%"
+      key: "%%CORE_ENCRYPT_KEY%%"
   env:
     aidial.config.files: '["/mnt/secrets-store/aidial.config.json"]'
     aidial.storage.provider: "aws-s3"

--- a/charts/dial/examples/azure/simple/README.md
+++ b/charts/dial/examples/azure/simple/README.md
@@ -60,8 +60,8 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%NAMESPACE%%` with namespace created above, e.g. `dial`
     - Replace `%%DOMAIN%%` with your domain name, e.g. `example.com`
     - Replace `%%DIAL_API_KEY%%` with generated value (`pwgen -s -1 64`)
-    - Replace `%%CORE_ENCRYPT_PASSWORD%%` with generated value (`pwgen -s -1 32`)
-    - Replace `%%CORE_ENCRYPT_SALT%%` with generated value (`pwgen -s -1 32`)
+    - Replace `%%CORE_ENCRYPT_SECRET%%` with generated value (`pwgen -s -1 32`)
+    - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%AZURE_MODEL_ENDPOINT%%` with Azure OpenAI Model Endpoint from [prerequisites](#prerequisites), e.g. `https://not-a-real-endpoint.openai.azure.com/openai/deployments/gpt-35-turbo/chat/completions`

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -12,7 +12,7 @@ core:
   configuration:
     encryption:
       secret: "%%CORE_ENCRYPT_SECRET%%"
-      key: "%CORE_ENCRYPT_KEY%"
+      key: "%%CORE_ENCRYPT_KEY%%"
   env:
     aidial.config.files: '["/mnt/secrets-store/aidial.config.json"]'
     aidial.storage.provider: "azureblob"

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -11,8 +11,8 @@ core:
     autorestart: '{{ dateInZone "2006-01-02 15:04:05Z" (now) "UTC" }}'
   configuration:
     encryption:
-      password: "%%CORE_ENCRYPT_PASSWORD%%"
-      salt: "%CORE_ENCRYPT_SALT%"
+      secret: "%%CORE_ENCRYPT_SECRET%%"
+      key: "%CORE_ENCRYPT_KEY%"
   env:
     aidial.config.files: '["/mnt/secrets-store/aidial.config.json"]'
     aidial.storage.provider: "azureblob"

--- a/charts/dial/examples/gcp/simple/README.md
+++ b/charts/dial/examples/gcp/simple/README.md
@@ -60,8 +60,8 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%NAMESPACE%%` with namespace created above, e.g. `dial`
     - Replace `%%DOMAIN%%` with your domain name, e.g. `example.com`
     - Replace `%%DIAL_API_KEY%%` with generated value (`pwgen -s -1 64`)
-    - Replace `%%CORE_ENCRYPT_PASSWORD%%` with generated value (`pwgen -s -1 32`)
-    - Replace `%%CORE_ENCRYPT_SALT%%` with generated value (`pwgen -s -1 32`)
+    - Replace `%%CORE_ENCRYPT_SECRET%%` with generated value (`pwgen -s -1 32`)
+    - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%GCP_CORE_SERVICE_ACCOUNT%%` with Google Service Account from [prerequisites](#prerequisites)

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -9,8 +9,8 @@ core:
     autorestart: '{{ dateInZone "2006-01-02 15:04:05Z" (now) "UTC" }}'
   configuration:
     encryption:
-      password: "%%CORE_ENCRYPT_PASSWORD%%"
-      salt: "%CORE_ENCRYPT_SALT%"
+      secret: "%%CORE_ENCRYPT_SECRET%%"
+      key: "%CORE_ENCRYPT_KEY%"
   env:
     aidial.config.files: '["/mnt/secrets-store/aidial.config.json"]'
     aidial.storage.provider: "google-cloud-storage"

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -10,7 +10,7 @@ core:
   configuration:
     encryption:
       secret: "%%CORE_ENCRYPT_SECRET%%"
-      key: "%CORE_ENCRYPT_KEY%"
+      key: "%%CORE_ENCRYPT_KEY%%"
   env:
     aidial.config.files: '["/mnt/secrets-store/aidial.config.json"]'
     aidial.storage.provider: "google-cloud-storage"

--- a/charts/dial/examples/generic/simple/README.md
+++ b/charts/dial/examples/generic/simple/README.md
@@ -59,8 +59,8 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%NAMESPACE%%` with namespace created above, e.g. `dial`
     - Replace `%%DOMAIN%%` with your domain name, e.g. `example.com`
     - Replace `%%DIAL_API_KEY%%` with generated value (`pwgen -s -1 64`)
-    - Replace `%%CORE_ENCRYPT_PASSWORD%%` with generated value (`pwgen -s -1 32`)
-    - Replace `%%CORE_ENCRYPT_SALT%%` with generated value (`pwgen -s -1 32`)
+    - Replace `%%CORE_ENCRYPT_SECRET%%` with generated value (`pwgen -s -1 32`)
+    - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%AZURE_MODEL_ENDPOINT%%` with Azure OpenAI Model Endpoint from [prerequisites](#prerequisites), e.g. `https://not-a-real-endpoint.openai.azure.com/openai/deployments/gpt-35-turbo/chat/completions`

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -5,8 +5,8 @@ core:
     autorestart: '{{ dateInZone "2006-01-02 15:04:05Z" (now) "UTC" }}'
   configuration:
     encryption:
-      password: "%%CORE_ENCRYPT_PASSWORD%%"
-      salt: "%CORE_ENCRYPT_SALT%"
+      secret: "%%CORE_ENCRYPT_SECRET%%"
+      key: "%CORE_ENCRYPT_KEY%"
   env:
     aidial.config.files: '["/mnt/secrets-store/aidial.config.json"]'
     aidial.identityProviders.fake.jwksUrl: "http://fakeJwksUrl"

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -6,7 +6,7 @@ core:
   configuration:
     encryption:
       secret: "%%CORE_ENCRYPT_SECRET%%"
-      key: "%CORE_ENCRYPT_KEY%"
+      key: "%%CORE_ENCRYPT_KEY%%"
   env:
     aidial.config.files: '["/mnt/secrets-store/aidial.config.json"]'
     aidial.identityProviders.fake.jwksUrl: "http://fakeJwksUrl"

--- a/charts/dial/values.yaml
+++ b/charts/dial/values.yaml
@@ -53,7 +53,7 @@ core:
   # -- Enable/disable ai-dial-core
   enabled: true
   image:
-    tag: 0.15.0
+    tag: 0.15.1
 
 ### ai-dial-chat configuration ###
 chat:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of DIAL might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Applicable issues

<!-- Please link the GitHub issues related to this PR here (You can reference an issue using #) -->
- fixes #

### Description of changes

- bump core image tag
- bump `dial-core` helm subchart version to `3.0.0`
- adjust examples to match new values names

### Additional information

In this version we have to reflect `ai-dial-core` [application configuration parameters renaming](https://github.com/epam/ai-dial-core/pull/455) in version `0.15.1+` by renaming several values in this chart.

- `core.configuration.encryption.password` parameter is renamed to `core.configuration.encryption.secret`
- `core.configuration.encryption.salt` parameter is changed to `core.configuration.encryption.key`

### How to upgrade to version 3.0.0

a) If using encryption Kubernetes secret created by the chart:

1. Update the parameters you have in your current deployment values (e.g. `values.yaml` file or set via `--set`) according to the changes below:
     - `core.configuration.encryption.password` --> `core.configuration.encryption.secret`
     - `core.configuration.encryption.salt` --> `core.configuration.encryption.key`
1. Delete the `*-encryption` secret, e.g. (replace `my-release` with the actual release name):

    ```console
    kubectl delete secret my-release-dial-core-encryption
    ```

1. Proceed with the helm upgrade as usual, e.g.:

    ```console
    helm upgrade my-release dial/dial -f values.yaml
    ```

b) If using your own managed Kubernetes secret (`core.configuration.encryption.existingSecret` is set):

1. Rename keys in your existing secret:

    - `aidial.encryption.password` --> `aidial.encryption.secret`
    - `aidial.encryption.salt` --> `aidial.encryption.key`

    You can update your existing secret to rename or move the keys using the following one-liner command (replace `<your-existing-secret-name>` and `<namespace>` with the actual values):

    ```console
      kubectl get secret <your-existing-secret-name> -o yaml -n <namespace> | jq '.data["aidial.encryption.secret"] = .data["aidial.encryption.password"] | .data["aidial.encryption.key"] = .data["aidial.encryption.salt"] | del(.data["aidial.encryption.password"], .data["aidial.encryption.salt"])' | kubectl replace -f -
    ```

1. Proceed with the helm upgrade as usual, e.g.:

    ```console
    helm upgrade my-release dial/dial -f values.yaml
    ```


### Testing

<!-- Please explain what testing was done. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/)
- [X] `appVersion` bumped in `Chart.yaml` if it's `dial` chart and any application version changed
- [X] Variables are documented in the `values.yaml` and added to the `README.md` using [helm-docs](https://github.com/norwoodj/helm-docs)
- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
