### PR TITLE
fix: default resources path for redis

### DIFF
--- a/charts/dial-core/Chart.yaml
+++ b/charts/dial-core/Chart.yaml
@@ -26,4 +26,4 @@ maintainers:
 name: dial-core
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial-core
-version: 3.0.0
+version: 3.0.1

--- a/charts/dial-core/README.md
+++ b/charts/dial-core/README.md
@@ -1,6 +1,6 @@
 # dial-core
 
-![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Helm chart for dial core
 
@@ -210,9 +210,9 @@ helm install my-release dial/dial-core -f values.yaml
 | redis.cluster.update.currentNumberOfReplicas | int | `0` |  |
 | redis.enabled | bool | `true` |  |
 | redis.redis.configmap | string | `"# Intentional gap from 2gb to 2Gi left\nmaxmemory 2gb\n# Evict using approximated LFU, only keys with an expire set\nmaxmemory-policy volatile-lfu"` |  |
+| redis.redis.resources.limits.memory | string | `"2Gi"` |  |
+| redis.redis.resources.requests.memory | string | `"2Gi"` |  |
 | redis.redis.useAOFPersistence | string | `"no"` | Whether to use AOF Persistence mode or not. We keep only RDB persistence (enabled by default) |
-| redis.resources.limits.memory | string | `"2Gi"` |  |
-| redis.resources.requests.memory | string | `"2Gi"` |  |
 | replicaCount | int | `1` | Number of dial-core replicas to deploy |
 | resources | object | `{}` | dial-core resource requests and limits ref: http://kubernetes.io/docs/user-guide/compute-resources/ |
 | schedulerName | string | `""` | Name of the k8s scheduler (other than default) for dial-core pods ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/ |

--- a/charts/dial-core/values.yaml
+++ b/charts/dial-core/values.yaml
@@ -506,12 +506,12 @@ logger:
 
 redis:
   enabled: true
-  resources:
-    requests:
-      memory: 2Gi
-    limits:
-      memory: 2Gi
   redis:
+    resources:
+      requests:
+        memory: 2Gi
+      limits:
+        memory: 2Gi
     # -- Whether to use AOF Persistence mode or not. We keep only RDB persistence (enabled by default)
     useAOFPersistence: "no"
     configmap: |-


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of DIAL might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Applicable issues

<!-- Please link the GitHub issues related to this PR here (You can reference an issue using #) -->
- fixes #

### Description of changes

Fix redis resources path, so it will be actually applied

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Testing

<!-- Please explain what testing was done. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/)
- [ ] `appVersion` bumped in `Chart.yaml` if it's `dial` chart and any application version changed
- [X] Variables are documented in the `values.yaml` and added to the `README.md` using [helm-docs](https://github.com/norwoodj/helm-docs)
- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
