### PR TITLE
feat: support ingress.tls.hosts templating in dial-extension helm chart

### DIFF
--- a/charts/dial-extension/Chart.yaml
+++ b/charts/dial-extension/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: dial-extension
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial-extension
-version: 1.0.5
+version: 1.0.6

--- a/charts/dial-extension/README.md
+++ b/charts/dial-extension/README.md
@@ -1,6 +1,6 @@
 # dial-extension
 
-![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Helm chart for dial extensions
 

--- a/charts/dial-extension/README.md
+++ b/charts/dial-extension/README.md
@@ -124,7 +124,7 @@ helm install my-release dial/dial-extension -f values.yaml
 | ingress.path | string | `"/"` | Default path for the ingress record NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers |
 | ingress.pathType | string | `"Prefix"` | Ingress path type |
 | ingress.serviceName | string | `""` | Change default name of service for the ingress record |
-| ingress.tls | list | `[]` | TLS configuration for additional hostname(s) to be covered with this ingress record ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls |
+| ingress.tls | list | `[]` | TLS configuration for additional hostname(s) to be covered with this ingress record (evaluated as a template) ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls |
 | initContainers | list | `[]` | Add additional init containers to the dial-extension pod(s) ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ |
 | labels | object | `{}` | Labels to add to dial-extension deployed objects |
 | lifecycleHooks | object | `{}` | for the dial-extension container(s) to automate configuration before or after startup |

--- a/charts/dial-extension/templates/ingress.yaml
+++ b/charts/dial-extension/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
 {{- end }}
 {{- if .Values.ingress.tls }}
-  tls: {{ toYaml .Values.ingress.tls | nindent 4 }}
+  tls: {{- include "common.tplvalues.render" (dict "value" .Values.ingress.tls "context" $) | nindent 4 }}
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}

--- a/charts/dial-extension/values.yaml
+++ b/charts/dial-extension/values.yaml
@@ -394,7 +394,7 @@ ingress:
   # -- An array with hostname(s) to be covered with the ingress record
   hosts:
     - dial-extension.local
-  # -- TLS configuration for additional hostname(s) to be covered with this ingress record
+  # -- TLS configuration for additional hostname(s) to be covered with this ingress record (evaluated as a template)
   # ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   tls:
     []


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of DIAL might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Applicable issues

<!-- Please link the GitHub issues related to this PR here (You can reference an issue using #) -->
- fixes #

### Description of changes

Add the ability to template `ingress.tls.hosts` values, preserving the ability to mention hosts that differ from `ingress.hosts`, e.g.:

```yaml
global:
  url: "example.com"

ingress:
  enabled: true
  ingressClassName: nginx
  annotations:
    cert-manager.io/cluster-issuer: "letsencrypt-production"
  hosts:
    - "themes-{{ .Values.global.url }}"
  tls:
    - secretName: "themes-tls-secret"
      hosts:
        - "themes-{{ .Values.global.url }}"
```

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Testing

<!-- Please explain what testing was done. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/)
- [ ] `appVersion` bumped in `Chart.yaml` if it's `dial` chart and any application version changed
- [X] Variables are documented in the `values.yaml` and added to the `README.md` using [helm-docs](https://github.com/norwoodj/helm-docs)
- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
