### PR TITLE
feat: bump dependencies in dial-core chart

### DIFF
--- a/charts/dial-core/Chart.yaml
+++ b/charts/dial-core/Chart.yaml
@@ -8,12 +8,12 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 2.14.1
+    version: 2.26.0
   - name: redis-cluster
     repository: https://charts.bitnami.com/bitnami
     alias: redis
     condition: redis.enabled
-    version: 9.1.5
+    version: 11.0.6
 description: Helm chart for dial core
 home: https://epam-rail.com
 icon: "https://docs.epam-rail.com/img/favicon.ico"
@@ -26,4 +26,4 @@ maintainers:
 name: dial-core
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial-core
-version: 3.0.2
+version: 4.0.0

--- a/charts/dial-core/README.md
+++ b/charts/dial-core/README.md
@@ -1,6 +1,6 @@
 # dial-core
 
-![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Helm chart for dial core
 
@@ -23,8 +23,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 2.14.1 |
-| https://charts.bitnami.com/bitnami | redis(redis-cluster) | 9.1.5 |
+| https://charts.bitnami.com/bitnami | common | 2.26.0 |
+| https://charts.bitnami.com/bitnami | redis(redis-cluster) | 11.0.6 |
 
 ## Installing the Chart
 


### PR DESCRIPTION
### Description of changes

- Bump bitnami-common helm chart version (must be aligned with all other dependency helm charts from bitnami on a higher level)
- Bump redis-cluster helm chart version, therefore redis-cluster application version `7.2.4` --> `7.4.1` upgrade.
No breaking changes are expected, however, bumping the major version to highlight Redis version upgrade.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/)
- [ ] `appVersion` bumped in `Chart.yaml` if it's `dial` chart and any application version changed
- [X] Variables are documented in the `values.yaml` and added to the `README.md` using [helm-docs](https://github.com/norwoodj/helm-docs)
- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
