### PR TITLE
chore: Document Core logger configuration update for 1.25 [skip ci]

### DIFF
--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -153,6 +153,25 @@ helm install my-release dial/dial -f values.yaml
 
 ## Upgrading
 
+### To 5.4.0
+
+> [!TIP]
+> If you don't use custom Core logger configuration, disregard the information below and proceed with Helm upgrade as usual.
+
+> [!CAUTION]
+> The upgrade require Core logger configuration update.
+
+Add `data_dir: "/var/tmp/vector"` to `core.logger.config` if custom vector config is used. This is required to run vector without root privileges.
+
+**Example:**
+
+```
+core:
+  logger:
+    config: |
+      data_dir: "/var/tmp/vector"
+```
+
 ### To 5.0.0
 
 > [!TIP]

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -69,6 +69,25 @@ helm install my-release dial/dial -f values.yaml
 
 ## Upgrading
 
+### To 5.4.0
+
+> [!TIP]
+> If you don't use custom Core logger configuration, disregard the information below and proceed with Helm upgrade as usual.
+
+> [!CAUTION]
+> The upgrade require Core logger configuration update.
+
+Add `data_dir: "/var/tmp/vector"` to `core.logger.config` if custom vector config is used. This is required to run vector without root privileges.
+
+**Example:**
+
+```
+core:
+  logger:
+    config: |
+      data_dir: "/var/tmp/vector"
+```
+
 ### To 5.0.0
 
 > [!TIP]


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of DIAL might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Applicable issues

<!-- Please link the GitHub issues related to this PR here (You can reference an issue using #) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made here. -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Testing

<!-- Please explain what testing was done. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/)
- [ ] `appVersion` bumped in `Chart.yaml` if it's `dial` chart and any application version changed
- [ ] Variables are documented in the `values.yaml` and added to the `README.md` using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
