### PR TITLE
chore: dial admin change kubernetes version (Chart.yaml)

### DIFF
--- a/charts/dial-admin/Chart.yaml
+++ b/charts/dial-admin/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: dial-admin
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial-admin
-version: 0.4.2
+version: 0.4.1

--- a/charts/dial-admin/Chart.yaml
+++ b/charts/dial-admin/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: dial-admin
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial-admin
-version: 0.4.1
+version: 0.4.2

--- a/charts/dial-admin/Chart.yaml
+++ b/charts/dial-admin/Chart.yaml
@@ -24,7 +24,7 @@ icon: "https://docs.dialx.ai/img/favicon.ico"
 keywords:
   - ai-dial
   - ai-dial-admin
-kubeVersion: ">=1.26.0-0"
+kubeVersion: ">=1.25.0-0"
 maintainers:
   - name: EPAM Systems
     url: https://github.com/epam

--- a/charts/dial-admin/README.md
+++ b/charts/dial-admin/README.md
@@ -1,6 +1,9 @@
 # dial-admin
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+
+
+
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square) 
 
 Helm chart for DIAL Admin
 
@@ -12,7 +15,7 @@ Helm chart for DIAL Admin
 
 ## Requirements
 
-Kubernetes: `>=1.26.0-0`
+Kubernetes: `>=1.25.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/charts/dial-admin/README.md
+++ b/charts/dial-admin/README.md
@@ -1,6 +1,6 @@
 # dial-admin
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 Helm chart for DIAL Admin
 

--- a/charts/dial-admin/README.md
+++ b/charts/dial-admin/README.md
@@ -1,6 +1,6 @@
 # dial-admin
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 Helm chart for DIAL Admin
 

--- a/charts/dial-admin/README.md
+++ b/charts/dial-admin/README.md
@@ -1,8 +1,6 @@
 # dial-admin
 
 
-
-
 ![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square) 
 
 Helm chart for DIAL Admin

--- a/charts/dial-admin/README.md
+++ b/charts/dial-admin/README.md
@@ -1,6 +1,6 @@
 # dial-admin
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square) 
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 Helm chart for DIAL Admin
 

--- a/charts/dial-admin/README.md
+++ b/charts/dial-admin/README.md
@@ -1,6 +1,5 @@
 # dial-admin
 
-
 ![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square) 
 
 Helm chart for DIAL Admin


### PR DESCRIPTION

### Applicable issues

<!-- Please link the GitHub issues related to this PR here (You can reference an issue using #) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made here. -->
Fix kubernetes version for dial admin chart to allow kubeversion 1.25
### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Testing

<!-- Please explain what testing was done. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/)
- [] `appVersion` bumped in `Chart.yaml` if it's `dial` chart and any application version changed
- [x] Variables are documented in the `values.yaml` and added to the `README.md` using [helm-docs](https://github.com/norwoodj/helm-docs)
- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
