### PR TITLE
fix: enable liveness probe for core

### DIFF
--- a/charts/dial/Chart.yaml
+++ b/charts/dial/Chart.yaml
@@ -70,4 +70,4 @@ maintainers:
 name: dial
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial
-version: 5.14.0
+version: 5.14.1

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -1,6 +1,6 @@
 # dial
 
-![Version: 5.14.0](https://img.shields.io/badge/Version-5.14.0-informational?style=flat-square) ![AppVersion: 1.34.0](https://img.shields.io/badge/AppVersion-1.34.0-informational?style=flat-square)
+![Version: 5.14.1](https://img.shields.io/badge/Version-5.14.1-informational?style=flat-square) ![AppVersion: 1.34.0](https://img.shields.io/badge/AppVersion-1.34.0-informational?style=flat-square)
 
 Umbrella chart for DIAL solution
 
@@ -114,6 +114,8 @@ helm install my-release dial/dial -f values.yaml
 | chat.readinessProbe.httpGet.path | string | `"/api/health"` |  |
 | core.enabled | bool | `true` | Enable/disable ai-dial-core |
 | core.image.tag | string | `"0.34.0"` |  |
+| core.livenessProbe.enabled | bool | `true` |  |
+| core.readinessProbe.enabled | bool | `true` |  |
 | dial.commonLabels."app.kubernetes.io/component" | string | `"adapter"` |  |
 | dial.enabled | bool | `false` | Enable/disable ai-dial-adapter-dial |
 | dial.image.repository | string | `"epam/ai-dial-adapter-dial"` |  |

--- a/charts/dial/values.yaml
+++ b/charts/dial/values.yaml
@@ -69,6 +69,10 @@ core:
   enabled: true
   image:
     tag: 0.34.0
+  livenessProbe:
+    enabled: true
+  readinessProbe:
+    enabled: true
 
 ### ai-dial-chat configuration ###
 chat:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of DIAL might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Applicable issues

<!-- Please link the GitHub issues related to this PR here (You can reference an issue using #) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made here. -->

- enable liveness probe for core

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Testing

<!-- Please explain what testing was done. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/)
- [ ] `appVersion` bumped in `Chart.yaml` if it's `dial` chart and any application version changed
- [X] Variables are documented in the `values.yaml` and added to the `README.md` using [helm-docs](https://github.com/norwoodj/helm-docs)
- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
