### PR TITLE
feat: DIAL release 1.43 - bump chart version to 6.2.0 and update component images

### DIFF
--- a/charts/dial/Chart.yaml
+++ b/charts/dial/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: MachineLearning
   licenses: Apache-2.0
 apiVersion: v2
-appVersion: "1.42.0"
+appVersion: "1.43.0"
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/dial/Chart.yaml
+++ b/charts/dial/Chart.yaml
@@ -60,4 +60,4 @@ maintainers:
 name: dial
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial
-version: 6.1.0
+version: 6.2.0

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -1,6 +1,6 @@
 # dial
 
-![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![AppVersion: 1.42.0](https://img.shields.io/badge/AppVersion-1.42.0-informational?style=flat-square)
+![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![AppVersion: 1.43.0](https://img.shields.io/badge/AppVersion-1.43.0-informational?style=flat-square)
 
 Umbrella chart for DIAL solution
 

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -1,6 +1,6 @@
 # dial
 
-![Version: 6.1.0](https://img.shields.io/badge/Version-6.1.0-informational?style=flat-square) ![AppVersion: 1.42.0](https://img.shields.io/badge/AppVersion-1.42.0-informational?style=flat-square)
+![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![AppVersion: 1.42.0](https://img.shields.io/badge/AppVersion-1.42.0-informational?style=flat-square)
 
 Umbrella chart for DIAL solution
 

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -85,7 +85,7 @@ helm install my-release dial/dial -f values.yaml
 | bedrock.containerSecurityContext.readOnlyRootFilesystem | bool | `false` |  |
 | bedrock.enabled | bool | `false` | Enable/disable ai-dial-adapter-bedrock |
 | bedrock.image.repository | string | `"epam/ai-dial-adapter-bedrock"` |  |
-| bedrock.image.tag | string | `"0.38.0"` |  |
+| bedrock.image.tag | string | `"0.39.0"` |  |
 | bedrock.livenessProbe.enabled | bool | `true` |  |
 | bedrock.readinessProbe.enabled | bool | `true` |  |
 | bedrock.resourcesPreset | string | `"micro"` |  |
@@ -95,7 +95,7 @@ helm install my-release dial/dial -f values.yaml
 | chat.containerSecurityContext.readOnlyRootFilesystem | bool | `false` |  |
 | chat.enabled | bool | `true` | Enable/disable ai-dial-chat |
 | chat.image.repository | string | `"epam/ai-dial-chat"` |  |
-| chat.image.tag | string | `"0.44.1"` |  |
+| chat.image.tag | string | `"0.45.0"` |  |
 | chat.livenessProbe.enabled | bool | `true` |  |
 | chat.livenessProbe.failureThreshold | int | `6` |  |
 | chat.livenessProbe.httpGet.path | string | `"/api/health"` |  |
@@ -104,14 +104,14 @@ helm install my-release dial/dial -f values.yaml
 | chat.readinessProbe.httpGet.path | string | `"/api/health"` |  |
 | chat.resourcesPreset | string | `"small"` |  |
 | core.enabled | bool | `true` | Enable/disable ai-dial-core |
-| core.image.tag | string | `"0.42.0"` |  |
+| core.image.tag | string | `"0.43.0"` |  |
 | core.livenessProbe.enabled | bool | `true` |  |
 | core.readinessProbe.enabled | bool | `true` |  |
 | dial.commonLabels."app.kubernetes.io/component" | string | `"adapter"` |  |
 | dial.containerSecurityContext.readOnlyRootFilesystem | bool | `false` |  |
 | dial.enabled | bool | `false` | Enable/disable ai-dial-adapter-dial |
 | dial.image.repository | string | `"epam/ai-dial-adapter-dial"` |  |
-| dial.image.tag | string | `"0.13.0"` |  |
+| dial.image.tag | string | `"0.14.0"` |  |
 | dial.livenessProbe.enabled | bool | `true` |  |
 | dial.readinessProbe.enabled | bool | `true` |  |
 | dial.resourcesPreset | string | `"micro"` |  |
@@ -144,7 +144,7 @@ helm install my-release dial/dial -f values.yaml
 | openai.containerSecurityContext.readOnlyRootFilesystem | bool | `false` |  |
 | openai.enabled | bool | `false` | Enable/disable ai-dial-adapter-openai |
 | openai.image.repository | string | `"epam/ai-dial-adapter-openai"` |  |
-| openai.image.tag | string | `"0.38.0"` |  |
+| openai.image.tag | string | `"0.39.0"` |  |
 | openai.livenessProbe.enabled | bool | `true` |  |
 | openai.readinessProbe.enabled | bool | `true` |  |
 | openai.resourcesPreset | string | `"micro"` |  |
@@ -155,7 +155,7 @@ helm install my-release dial/dial -f values.yaml
 | themes.containerSecurityContext.runAsUser | int | `101` |  |
 | themes.enabled | bool | `true` | Enable/disable ai-dial-chat-themes |
 | themes.image.repository | string | `"epam/ai-dial-chat-themes"` |  |
-| themes.image.tag | string | `"0.14.0"` |  |
+| themes.image.tag | string | `"0.15.0"` |  |
 | themes.livenessProbe.enabled | bool | `true` |  |
 | themes.podSecurityContext.fsGroup | int | `101` |  |
 | themes.readinessProbe.enabled | bool | `true` |  |
@@ -163,7 +163,7 @@ helm install my-release dial/dial -f values.yaml
 | vertexai.containerSecurityContext.readOnlyRootFilesystem | bool | `false` |  |
 | vertexai.enabled | bool | `false` | Enable/disable ai-dial-adapter-vertexai |
 | vertexai.image.repository | string | `"epam/ai-dial-adapter-vertexai"` |  |
-| vertexai.image.tag | string | `"0.34.0"` |  |
+| vertexai.image.tag | string | `"0.35.0"` |  |
 | vertexai.livenessProbe.enabled | bool | `true` |  |
 | vertexai.readinessProbe.enabled | bool | `true` |  |
 | vertexai.resourcesPreset | string | `"small"` |  |

--- a/charts/dial/values.yaml
+++ b/charts/dial/values.yaml
@@ -66,7 +66,7 @@ core:
   # -- Enable/disable ai-dial-core
   enabled: true
   image:
-    tag: 0.42.0
+    tag: 0.43.0
   livenessProbe:
     enabled: true
   readinessProbe:
@@ -80,7 +80,7 @@ chat:
     app.kubernetes.io/component: "application"
   image:
     repository: epam/ai-dial-chat
-    tag: 0.44.1
+    tag: 0.45.0
   containerPorts:
     http: 3000
   livenessProbe:
@@ -107,7 +107,7 @@ themes:
     app.kubernetes.io/component: "webserver"
   image:
     repository: epam/ai-dial-chat-themes
-    tag: 0.14.0
+    tag: 0.15.0
   containerPorts:
     http: 8080
   podSecurityContext:
@@ -129,7 +129,7 @@ openai:
     app.kubernetes.io/component: "adapter"
   image:
     repository: epam/ai-dial-adapter-openai
-    tag: 0.38.0
+    tag: 0.39.0
   # env:
   #   DIAL_USE_FILE_STORAGE: "true"
   #   DIAL_URL: "http://{{ .Release.Name }}-core"
@@ -151,7 +151,7 @@ bedrock:
     app.kubernetes.io/component: "adapter"
   image:
     repository: epam/ai-dial-adapter-bedrock
-    tag: 0.38.0
+    tag: 0.39.0
   # env:
   #   DIAL_URL: "http://{{ .Release.Name }}-core"
   secrets: {}
@@ -176,7 +176,7 @@ vertexai:
     app.kubernetes.io/component: "adapter"
   image:
     repository: epam/ai-dial-adapter-vertexai
-    tag: 0.34.0
+    tag: 0.35.0
   # env:
   #   DIAL_URL: "http://{{ .Release.Name }}-core"
   livenessProbe:
@@ -197,7 +197,7 @@ dial:
     app.kubernetes.io/component: "adapter"
   image:
     repository: epam/ai-dial-adapter-dial
-    tag: 0.13.0
+    tag: 0.14.0
   # env:
   #   DIAL_URL: "http://{{ .Release.Name }}-core"
   livenessProbe:


### PR DESCRIPTION
### Description of changes

Bump of version of the following applications:

- ai-dial-core: 0.42.0 => 0.43.0
- ai-dial-chat: 0.44.1 => 0.45.0
- ai-dial-adapter-openai: 0.38.0 => 0.39.0
- ai-dial-adapter-bedrock: 0.38.0 => 0.39.0
- ai-dial-adapter-vertexai: 0.34.0 => 0.35.0
- ai-dial-adapter-dial: 0.13.0 => 0.14.0

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/)
- [X] `appVersion` bumped in `Chart.yaml` if it's `dial` chart and any application version changed
- [X] Variables are documented in the `values.yaml` and added to the `README.md` using [helm-docs](https://github.com/norwoodj/helm-docs)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
