### PR TITLE
feat(dial-admin): add support for http routes for dial-admin chart

### DIFF
--- a/charts/dial-admin/Chart.yaml
+++ b/charts/dial-admin/Chart.yaml
@@ -36,4 +36,4 @@ maintainers:
 name: dial-admin
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial-admin
-version: 0.14.1
+version: 0.15.0

--- a/charts/dial-admin/Chart.yaml
+++ b/charts/dial-admin/Chart.yaml
@@ -10,12 +10,12 @@ dependencies:
       - bitnami-common
     version: 2.31.1
   - name: dial-extension
-    version: 3.0.1
+    version: 3.1.0
     repository: https://charts.dialx.ai
     alias: frontend
     condition: frontend.enabled
   - name: dial-extension
-    version: 3.0.1
+    version: 3.1.0
     repository: https://charts.dialx.ai
     alias: manager
     condition: manager.enabled
@@ -36,4 +36,4 @@ maintainers:
 name: dial-admin
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial-admin
-version: 0.14.0
+version: 0.15.0

--- a/charts/dial-admin/Chart.yaml
+++ b/charts/dial-admin/Chart.yaml
@@ -10,12 +10,12 @@ dependencies:
       - bitnami-common
     version: 2.31.1
   - name: dial-extension
-    version: 3.1.0
+    version: 3.1.1
     repository: https://charts.dialx.ai
     alias: frontend
     condition: frontend.enabled
   - name: dial-extension
-    version: 3.1.0
+    version: 3.1.1
     repository: https://charts.dialx.ai
     alias: manager
     condition: manager.enabled
@@ -36,4 +36,4 @@ maintainers:
 name: dial-admin
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial-admin
-version: 0.15.0
+version: 0.14.1

--- a/charts/dial-admin/README.md
+++ b/charts/dial-admin/README.md
@@ -1,6 +1,6 @@
 # dial-admin
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![AppVersion: 0.17.0](https://img.shields.io/badge/AppVersion-0.17.0-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![AppVersion: 0.17.0](https://img.shields.io/badge/AppVersion-0.17.0-informational?style=flat-square)
 
 Helm chart for DIAL Admin
 
@@ -16,8 +16,8 @@ Kubernetes: `>=1.25.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.dialx.ai | frontend(dial-extension) | 3.0.1 |
-| https://charts.dialx.ai | manager(dial-extension) | 3.0.1 |
+| https://charts.dialx.ai | frontend(dial-extension) | 3.1.0 |
+| https://charts.dialx.ai | manager(dial-extension) | 3.1.0 |
 | oci://registry-1.docker.io/bitnamicharts | common | 2.31.1 |
 | oci://registry-1.docker.io/bitnamicharts | postgresql | 16.7.12 |
 
@@ -118,6 +118,12 @@ helm install my-release dial/dial-admin -f values.yaml
 | backend.extraVolumes | list | `[]` | Optionally specify extra list of additional volumes for the dial-admin backend pod(s) |
 | backend.hostAliases | list | `[]` | dial-admin backend pods host aliases [Documentation](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/) |
 | backend.hostNetwork | bool | `false` | Enable Host Network If hostNetwork true, then dnsPolicy is set to ClusterFirstWithHostNet |
+| backend.httpRoute | object | [Documentation](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/) | HTTPRoute configuration (Gateway API) |
+| backend.httpRoute.annotations | object | `{}` | Additional annotations for the HTTPRoute resource |
+| backend.httpRoute.enabled | bool | `false` | Enable HTTPRoute resource creation |
+| backend.httpRoute.hostnames | list | `[]` | Hostnames to match for routing |
+| backend.httpRoute.parentRefs | list | `[]` | Gateway parent references (required when enabled) [Documentation](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#parentreference) |
+| backend.httpRoute.rules | list | `[]` | Custom routing rules. When empty, a default rule is created that routes all traffic (PathPrefix /) to the service [Documentation](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprouterule) |
 | backend.image | object | [Documentation](https://kubernetes.io/docs/concepts/containers/images/) | Section to configure the image. |
 | backend.image.digest | string | `""` | Image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended) |
 | backend.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |

--- a/charts/dial-admin/README.md
+++ b/charts/dial-admin/README.md
@@ -1,6 +1,6 @@
 # dial-admin
 
-![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![AppVersion: 0.17.0](https://img.shields.io/badge/AppVersion-0.17.0-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![AppVersion: 0.17.0](https://img.shields.io/badge/AppVersion-0.17.0-informational?style=flat-square)
 
 Helm chart for DIAL Admin
 

--- a/charts/dial-admin/README.md
+++ b/charts/dial-admin/README.md
@@ -1,6 +1,6 @@
 # dial-admin
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![AppVersion: 0.17.0](https://img.shields.io/badge/AppVersion-0.17.0-informational?style=flat-square)
+![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![AppVersion: 0.17.0](https://img.shields.io/badge/AppVersion-0.17.0-informational?style=flat-square)
 
 Helm chart for DIAL Admin
 
@@ -16,8 +16,8 @@ Kubernetes: `>=1.25.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.dialx.ai | frontend(dial-extension) | 3.1.0 |
-| https://charts.dialx.ai | manager(dial-extension) | 3.1.0 |
+| https://charts.dialx.ai | frontend(dial-extension) | 3.1.1 |
+| https://charts.dialx.ai | manager(dial-extension) | 3.1.1 |
 | oci://registry-1.docker.io/bitnamicharts | common | 2.31.1 |
 | oci://registry-1.docker.io/bitnamicharts | postgresql | 16.7.12 |
 

--- a/charts/dial-admin/templates/backend/httproute.yaml
+++ b/charts/dial-admin/templates/backend/httproute.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.backend.enabled .Values.backend.httpRoute.enabled -}}
+
+{{- if or (not .Values.backend.httpRoute.parentRefs) (lt (len .Values.backend.httpRoute.parentRefs) 1) }}
+{{- fail (printf "backend.httpRoute.parentRefs must be defined and contain at least one gateway reference.") }}
+{{- end -}}
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "dialAdmin.backend.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: backend
+  {{- if or .Values.backend.httpRoute.annotations .Values.commonAnnotations }}
+  {{- $annotations := merge .Values.backend.httpRoute.annotations .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs: {{- include "common.tplvalues.render" (dict "value" .Values.backend.httpRoute.parentRefs "context" $) | nindent 4 }}
+  {{- if .Values.backend.httpRoute.hostnames }}
+  hostnames: {{- include "common.tplvalues.render" (dict "value" .Values.backend.httpRoute.hostnames "context" $) | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.backend.httpRoute.rules }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.backend.httpRoute.rules "context" $ ) | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ template "dialAdmin.backend.fullname" . }}
+          port: {{ .Values.backend.service.ports.http }}
+    {{- end }}
+{{- end }}

--- a/charts/dial-admin/values.schema.json
+++ b/charts/dial-admin/values.schema.json
@@ -394,6 +394,58 @@
                     },
                     "type": "object"
                 },
+                "httpRoute": {
+                    "type": "object",
+                    "description": "HTTPRoute configuration (Gateway API)",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable HTTPRoute resource creation",
+                            "default": false
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Additional annotations for the HTTPRoute resource",
+                            "default": {}
+                        },
+                        "parentRefs": {
+                            "type": "array",
+                            "description": "Gateway parent references (required when enabled)",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Name of the Gateway resource"
+                                    },
+                                    "namespace": {
+                                        "type": "string",
+                                        "description": "Namespace of the Gateway resource"
+                                    },
+                                    "sectionName": {
+                                        "type": "string",
+                                        "description": "Section name of the Gateway listener"
+                                    }
+                                },
+                                "required": ["name"]
+                            }
+                        },
+                        "hostnames": {
+                            "type": "array",
+                            "description": "Hostnames to match for routing",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "Custom routing rules. When empty, a default rule routes all traffic to the service",
+                            "items": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
                 "serviceAccount": {
                     "properties": {
                         "create": {

--- a/charts/dial-admin/values.yaml
+++ b/charts/dial-admin/values.yaml
@@ -311,6 +311,41 @@ backend:
       # clientIP:
       #   timeoutSeconds: 300
 
+  # -- HTTPRoute configuration (Gateway API)
+  # @default -- [Documentation](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/)
+  httpRoute:
+    # -- Enable HTTPRoute resource creation
+    enabled: false
+    # -- Additional annotations for the HTTPRoute resource
+    annotations: {}
+    # -- Gateway parent references (required when enabled)
+    # [Documentation](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#parentreference)
+    parentRefs: []
+      # - name: my-gateway
+      #   namespace: gateway-ns
+      #   sectionName: https
+    # -- Hostnames to match for routing
+    hostnames: []
+      # - dial-admin-backend.example.com
+    # -- Custom routing rules. When empty, a default rule is created that routes all traffic (PathPrefix /) to the service
+    # [Documentation](https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprouterule)
+    rules: []
+      # - matches:
+      #     - path:
+      #         type: PathPrefix
+      #         value: /api
+      #   backendRefs:
+      #     - name: my-service
+      #       port: 80
+      #   filters:
+      #     - type: URLRewrite
+      #       urlRewrite:
+      #         path:
+      #           type: ReplacePrefixMatch
+      #           replacePrefixMatch: /
+      #   timeouts:
+      #     request: 30s
+
   # -- ServiceAccount configuration
   # @default -- [Documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
   serviceAccount:


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR here (You can reference an issue using #) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made here. -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Testing

<!-- Please explain what testing was done. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/)
- [x] `appVersion` bumped in `Chart.yaml` if it's `dial` chart and any application version changed
- [x] Variables are documented in the `values.yaml` and added to the `README.md` using [helm-docs](https://github.com/norwoodj/helm-docs)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
