### PR TITLE
feat: DIAL release 1.45

### DIFF
--- a/charts/dial-admin/Chart.yaml
+++ b/charts/dial-admin/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: MachineLearning
   licenses: Apache-2.0
 apiVersion: v2
-appVersion: "0.17.0"
+appVersion: "0.18.0"
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts
@@ -36,4 +36,4 @@ maintainers:
 name: dial-admin
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial-admin
-version: 0.15.0
+version: 0.16.0

--- a/charts/dial-admin/README.md
+++ b/charts/dial-admin/README.md
@@ -1,6 +1,6 @@
 # dial-admin
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![AppVersion: 0.17.0](https://img.shields.io/badge/AppVersion-0.17.0-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![AppVersion: 0.18.0](https://img.shields.io/badge/AppVersion-0.18.0-informational?style=flat-square)
 
 Helm chart for DIAL Admin
 
@@ -130,7 +130,7 @@ helm install my-release dial/dial-admin -f values.yaml
 | backend.image.pullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. [Documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) |
 | backend.image.registry | string | `"docker.io"` | Image registry |
 | backend.image.repository | string | `"epam/ai-dial-admin-backend"` | Image repository |
-| backend.image.tag | string | `"0.17.0"` | Image tag (immutable tags are recommended) |
+| backend.image.tag | string | `"0.18.0"` | Image tag (immutable tags are recommended) |
 | backend.initContainers | list | `[]` | Add additional init containers to the dial-admin backend pod(s) [Documentation](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) |
 | backend.lifecycleHooks | object | `{}` | for the dial-admin backend container(s) to automate configuration before or after startup |
 | backend.livenessProbe | object | [Documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes) | Liveness Probes configuration |
@@ -254,7 +254,7 @@ helm install my-release dial/dial-admin -f values.yaml
 | frontend.image.pullPolicy | string | `"Always"` | Frontend image pull policy |
 | frontend.image.registry | string | `"docker.io"` | Frontend image registry |
 | frontend.image.repository | string | `"epam/ai-dial-admin-frontend"` | Frontend image repository |
-| frontend.image.tag | string | `"0.17.1"` | Frontend image tag |
+| frontend.image.tag | string | `"0.18.0"` | Frontend image tag |
 | frontend.resourcesPreset | string | `"micro"` | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if `resources` is set (recommended for production). [Documentation](https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15) |
 | fullnameOverride | string | `""` | String to fully override common.names.fullname |
 | global.compatibility.openshift.adaptSecurityContext | string | `"disabled"` | Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation) |
@@ -280,7 +280,7 @@ helm install my-release dial/dial-admin -f values.yaml
 | manager.image | object | [Documentation](https://kubernetes.io/docs/concepts/containers/images/) | Section to configure the image. |
 | manager.image.registry | string | `"docker.io"` | Image registry |
 | manager.image.repository | string | `"epam/ai-dial-admin-deployment-manager-backend"` | Image repository |
-| manager.image.tag | string | `"0.17.0"` | Image tag (immutable tags are recommended) |
+| manager.image.tag | string | `"0.18.0"` | Image tag (immutable tags are recommended) |
 | manager.rbac.create | bool | `true` |  |
 | manager.resourcesPreset | string | `"small"` | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if `resources` is set (recommended for production). [Documentation](https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15) |
 | manager.serviceAccount.create | bool | `true` |  |

--- a/charts/dial-admin/values.yaml
+++ b/charts/dial-admin/values.yaml
@@ -36,7 +36,7 @@ backend:
     # -- Image repository
     repository: epam/ai-dial-admin-backend
     # -- Image tag (immutable tags are recommended)
-    tag: 0.17.0
+    tag: 0.18.0
     # -- Image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
     digest: ""
     # -- Image pull policy
@@ -547,7 +547,7 @@ frontend:
     # -- Frontend image repository
     repository: epam/ai-dial-admin-frontend
     # -- Frontend image tag
-    tag: 0.17.1
+    tag: 0.18.0
     # -- Frontend image pull policy
     pullPolicy: Always
 
@@ -574,7 +574,7 @@ manager:
     # -- Image repository
     repository: epam/ai-dial-admin-deployment-manager-backend
     # -- Image tag (immutable tags are recommended)
-    tag: 0.17.0
+    tag: 0.18.0
 
   commonAnnotations: {}
 

--- a/charts/dial/Chart.yaml
+++ b/charts/dial/Chart.yaml
@@ -60,4 +60,4 @@ maintainers:
 name: dial
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial
-version: 6.4.0
+version: 6.4.1

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -1,6 +1,6 @@
 # dial
 
-![Version: 6.4.0](https://img.shields.io/badge/Version-6.4.0-informational?style=flat-square) ![AppVersion: 1.44.0](https://img.shields.io/badge/AppVersion-1.44.0-informational?style=flat-square)
+![Version: 6.4.1](https://img.shields.io/badge/Version-6.4.1-informational?style=flat-square) ![AppVersion: 1.44.0](https://img.shields.io/badge/AppVersion-1.44.0-informational?style=flat-square)
 
 Umbrella chart for DIAL solution
 
@@ -85,7 +85,7 @@ helm install my-release dial/dial -f values.yaml
 | bedrock.containerSecurityContext.readOnlyRootFilesystem | bool | `false` |  |
 | bedrock.enabled | bool | `false` | Enable/disable ai-dial-adapter-bedrock |
 | bedrock.image.repository | string | `"epam/ai-dial-adapter-bedrock"` |  |
-| bedrock.image.tag | string | `"0.40.0"` |  |
+| bedrock.image.tag | string | `"0.41.0"` |  |
 | bedrock.livenessProbe.enabled | bool | `true` |  |
 | bedrock.readinessProbe.enabled | bool | `true` |  |
 | bedrock.resourcesPreset | string | `"micro"` |  |
@@ -95,7 +95,7 @@ helm install my-release dial/dial -f values.yaml
 | chat.containerSecurityContext.readOnlyRootFilesystem | bool | `false` |  |
 | chat.enabled | bool | `true` | Enable/disable ai-dial-chat |
 | chat.image.repository | string | `"epam/ai-dial-chat"` |  |
-| chat.image.tag | string | `"0.46.0"` |  |
+| chat.image.tag | string | `"0.47.0"` |  |
 | chat.livenessProbe.enabled | bool | `true` |  |
 | chat.livenessProbe.failureThreshold | int | `6` |  |
 | chat.livenessProbe.httpGet.path | string | `"/api/health"` |  |
@@ -104,14 +104,14 @@ helm install my-release dial/dial -f values.yaml
 | chat.readinessProbe.httpGet.path | string | `"/api/health"` |  |
 | chat.resourcesPreset | string | `"small"` |  |
 | core.enabled | bool | `true` | Enable/disable ai-dial-core |
-| core.image.tag | string | `"0.44.0"` |  |
+| core.image.tag | string | `"0.45.0"` |  |
 | core.livenessProbe.enabled | bool | `true` |  |
 | core.readinessProbe.enabled | bool | `true` |  |
 | dial.commonLabels."app.kubernetes.io/component" | string | `"adapter"` |  |
 | dial.containerSecurityContext.readOnlyRootFilesystem | bool | `false` |  |
 | dial.enabled | bool | `false` | Enable/disable ai-dial-adapter-dial |
 | dial.image.repository | string | `"epam/ai-dial-adapter-dial"` |  |
-| dial.image.tag | string | `"0.15.0"` |  |
+| dial.image.tag | string | `"0.16.0"` |  |
 | dial.livenessProbe.enabled | bool | `true` |  |
 | dial.readinessProbe.enabled | bool | `true` |  |
 | dial.resourcesPreset | string | `"micro"` |  |
@@ -144,7 +144,7 @@ helm install my-release dial/dial -f values.yaml
 | openai.containerSecurityContext.readOnlyRootFilesystem | bool | `false` |  |
 | openai.enabled | bool | `false` | Enable/disable ai-dial-adapter-openai |
 | openai.image.repository | string | `"epam/ai-dial-adapter-openai"` |  |
-| openai.image.tag | string | `"0.40.0"` |  |
+| openai.image.tag | string | `"0.41.0"` |  |
 | openai.livenessProbe.enabled | bool | `true` |  |
 | openai.readinessProbe.enabled | bool | `true` |  |
 | openai.resourcesPreset | string | `"micro"` |  |
@@ -163,7 +163,7 @@ helm install my-release dial/dial -f values.yaml
 | vertexai.containerSecurityContext.readOnlyRootFilesystem | bool | `false` |  |
 | vertexai.enabled | bool | `false` | Enable/disable ai-dial-adapter-vertexai |
 | vertexai.image.repository | string | `"epam/ai-dial-adapter-vertexai"` |  |
-| vertexai.image.tag | string | `"0.36.0"` |  |
+| vertexai.image.tag | string | `"0.37.0"` |  |
 | vertexai.livenessProbe.enabled | bool | `true` |  |
 | vertexai.readinessProbe.enabled | bool | `true` |  |
 | vertexai.resourcesPreset | string | `"small"` |  |

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -155,7 +155,7 @@ helm install my-release dial/dial -f values.yaml
 | themes.containerSecurityContext.runAsUser | int | `101` |  |
 | themes.enabled | bool | `true` | Enable/disable ai-dial-chat-themes |
 | themes.image.repository | string | `"epam/ai-dial-chat-themes"` |  |
-| themes.image.tag | string | `"0.16.0"` |  |
+| themes.image.tag | string | `"0.17.0"` |  |
 | themes.livenessProbe.enabled | bool | `true` |  |
 | themes.podSecurityContext.fsGroup | int | `101` |  |
 | themes.readinessProbe.enabled | bool | `true` |  |

--- a/charts/dial/values.yaml
+++ b/charts/dial/values.yaml
@@ -107,7 +107,7 @@ themes:
     app.kubernetes.io/component: "webserver"
   image:
     repository: epam/ai-dial-chat-themes
-    tag: 0.16.0
+    tag: 0.17.0
   containerPorts:
     http: 8080
   podSecurityContext:

--- a/charts/dial/values.yaml
+++ b/charts/dial/values.yaml
@@ -66,7 +66,7 @@ core:
   # -- Enable/disable ai-dial-core
   enabled: true
   image:
-    tag: 0.44.0
+    tag: 0.45.0
   livenessProbe:
     enabled: true
   readinessProbe:
@@ -80,7 +80,7 @@ chat:
     app.kubernetes.io/component: "application"
   image:
     repository: epam/ai-dial-chat
-    tag: 0.46.0
+    tag: 0.47.0
   containerPorts:
     http: 3000
   livenessProbe:
@@ -129,7 +129,7 @@ openai:
     app.kubernetes.io/component: "adapter"
   image:
     repository: epam/ai-dial-adapter-openai
-    tag: 0.40.0
+    tag: 0.41.0
   # env:
   #   DIAL_USE_FILE_STORAGE: "true"
   #   DIAL_URL: "http://{{ .Release.Name }}-core"
@@ -151,7 +151,7 @@ bedrock:
     app.kubernetes.io/component: "adapter"
   image:
     repository: epam/ai-dial-adapter-bedrock
-    tag: 0.40.0
+    tag: 0.41.0
   # env:
   #   DIAL_URL: "http://{{ .Release.Name }}-core"
   secrets: {}
@@ -176,7 +176,7 @@ vertexai:
     app.kubernetes.io/component: "adapter"
   image:
     repository: epam/ai-dial-adapter-vertexai
-    tag: 0.36.0
+    tag: 0.37.0
   # env:
   #   DIAL_URL: "http://{{ .Release.Name }}-core"
   livenessProbe:
@@ -197,7 +197,7 @@ dial:
     app.kubernetes.io/component: "adapter"
   image:
     repository: epam/ai-dial-adapter-dial
-    tag: 0.15.0
+    tag: 0.16.0
   # env:
   #   DIAL_URL: "http://{{ .Release.Name }}-core"
   livenessProbe:


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made here. -->
Bump of version of the following applications:

- ai-dial-core: 0.44.0 => 0.45.0
- ai-dial-chat: 0.46.0 => 0.47.0
- ai-dial-adapter-openai: 0.40.0 => 0.41.0
- ai-dial-adapter-bedrock: 0.40.0 => 0.41.0
- ai-dial-adapter-vertexai: 0.36.0 => 0.37.0
- ai-dial-adapter-dial: 0.14.0 => 0.15.0
- ai-dial-chat-themes: 0.16.0 => 0.17.0
- ai-dial-quickapps-backend: 0.8.0 => 0.9.0
- ai-dial-admin-backend: 0.17.0 => 0.18.0
- ai-dial-admin-frontend: 0.17.0 => 0.18.0
- ai-dial-admin-deployment-manager-backend: 0.17.0 => 0.18.0

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/)
- [x] `appVersion` bumped in `Chart.yaml` if it's `dial` chart and any application version changed
- [x] Variables are documented in the `values.yaml` and added to the `README.md` using [helm-docs](https://github.com/norwoodj/helm-docs)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
