### PR TITLE
feat(dial): Update of the dial-core chart containing the replacement of Redis Cluster with Valkey

### DIFF
--- a/charts/dial/.helmignore
+++ b/charts/dial/.helmignore
@@ -24,4 +24,5 @@
 *.lock
 OWNERS
 README.md.gotmpl
+.markdownlint.yaml
 ci/

--- a/charts/dial/.markdownlint.yaml
+++ b/charts/dial/.markdownlint.yaml
@@ -1,0 +1,7 @@
+# Disable rules that cannot be controlled in the README.md.gotmpl template
+# because they arise from helm-docs' built-in chart.requirementsSection and
+# chart.valuesSection templates.
+MD013: false  # line-length: values table rows and badge lines exceed 80 chars
+MD028: false  # no-blanks-blockquote: intentional consecutive [!TIP]+[!CAUTION] alert blocks throughout upgrade guide
+MD034: false  # no-bare-urls: bare URLs in auto-generated requirements table
+MD060: false  # table-column-style: column alignment in auto-generated tables

--- a/charts/dial/Chart.yaml
+++ b/charts/dial/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: https://charts.dialx.ai
     alias: core
     condition: core.enabled
-    version: 5.2.0
+    version: 6.0.0
   - name: dial-extension
     repository: https://charts.dialx.ai
     alias: chat
@@ -60,4 +60,4 @@ maintainers:
 name: dial
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial
-version: 6.5.0
+version: 7.0.0

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -180,7 +180,6 @@ helm install my-release dial/dial -f values.yaml
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
 
 - `Redis` replaced with `Valkey`
-- Install `Gateway API CRD`
 - `dial/dial-core` Helm chart version bumped from `5.2.0` to `6.0.0`
   - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
     - **Cluster → non‑clustered deployment**. We moved away from Redis Cluster.
@@ -188,21 +187,6 @@ In this version, we've updated the following underlying dependencies, some of wh
     - **Review memory / resources for Valkey**. Previous `redisCluster.*` values are ignored.
       Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.).
       This is not an obvious change without revisiting our values.
-
-1. If using the non-managed Kubernetes cluster, install `CRD Gateway API` and check `CRD Gateway API` with the following commands:
-
-    Install
-    ```shell
-    kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/standard-install.yaml
-    ```
-
-    Check
-    ```shell
-    kubectl get crd httproutes.gateway.networking.k8s.io
-
-    NAME                                   CREATED AT
-    httproutes.gateway.networking.k8s.io   %DATE%
-    ```
 
 1. If using a managed Kubernetes cluster, follow the service provider's instructions.
 
@@ -590,7 +574,7 @@ core:
 
 ### Use an external Valkey database
 
-You may want the application to connect to an external Valkey (or Redis-compatible) database rather than the one provided by the Helm chart — for example, when using a cloud-managed service such as AWS ElastiCache or Azure Cache for Redis. To do this, set `core.valkey.enabled` to `false` and specify the connection details:
+You may want the application to connect to an external Valkey (or Redis-compatible) database rather than the one provided by the Helm chart - for example, when using a cloud-managed service such as AWS ElastiCache or Azure Cache for Redis. To do this, set `core.valkey.enabled` to `false` and specify the connection details:
 
 ```yaml
 core:

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -188,9 +188,7 @@ In this version, we've updated the following underlying dependencies, some of wh
       Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.). 
       This is not an obvious change without revisiting our values.
 
-> [!TIP]
-> If you don't use external Redis, disregard the information below and proceed to the next step.
-1. Replace Redis-related config section in `values.yaml`
+1. If you use external Redis replace Redis-related config section in `values.yaml`
 
     From
     ```yaml
@@ -215,7 +213,7 @@ In this version, we've updated the following underlying dependencies, some of wh
           password: "%%REDIS_PASSWORD%%"
     ```
 
-1. Adding `values.yaml` with the following  Valkey config section. Strictly follow the indentation
+1. Adding `values.yaml` with the following Valkey config section. Strictly follow the indentation
 
     ```yaml
     core:
@@ -225,6 +223,7 @@ In this version, we've updated the following underlying dependencies, some of wh
           enabled: true
           aclUsers:
             default:
+              permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
               password: "%%REDIS_PASSWORD%%"
     ```
 

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -175,6 +175,8 @@ helm install my-release dial/dial -f values.yaml
 > [!CAUTION]
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
 > If you don't use embeded Redis, disregard the information below.
+> Strictly follow the indentation.
+> Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
 - `Redis` replaced with `Valkey`
@@ -191,9 +193,6 @@ In this version, we've updated the following underlying dependencies, some of wh
     ```
 
 1. Adding `values.yaml` with the following  Valkey config section. Strictly follow the indentation
-    > [!tip]
-    > Strictly follow the indentation
-    > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey)
 
     ```yaml
     valkey:

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -175,35 +175,57 @@ helm install my-release dial/dial -f values.yaml
 > [!CAUTION]
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
 > If you don't use embeded Redis, disregard the information below.
-
-> [!TIP]
-> Strictly follow the indentation.
 > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
+>
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
 - `Redis` replaced with `Valkey`
 - `dial/dial-core` Helm chart version bumped from to `5.2.0` to `6.0.0`
   - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
-    - `redis` replaced with `valkey` version bumped to `9.0.2`
+    - **Cluster → non‑clustered deployment**. We moved away from Redis Cluster. 
+      For production you should review your HA/scale strategy and adjust accordingly.
+    - **Review memory / resources for Valkey**. Previous `redisCluster.*` values are ignored. 
+      Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.). 
+      This is not an obvious change without revisiting our values.
+
+> [!TIP]
+> If you don't use external Redis, disregard the information below and proceed to the next step.
+1. Replace Redis-related config section in `values.yaml`
+
+    From
+    ```yaml
+    core:
+      redis:
+        enabled: false
+    ```
+
+    To
+    ```yaml
+    core:
+      valkey:
+        enabled: false
+    ```
 
 1. Delete Redis-related config section in `values.yaml`
 
     ```yaml
-      redis:
-        enabled: true
-        password: "%%REDIS_PASSWORD%%"
+      core:
+        redis:
+          enabled: true
+          password: "%%REDIS_PASSWORD%%"
     ```
 
 1. Adding `values.yaml` with the following  Valkey config section. Strictly follow the indentation
 
     ```yaml
-    valkey:
-      enabled: true
-      auth:
+    core:
+      valkey:
         enabled: true
-        aclUsers:
-          default:
-            password: "%%REDIS_PASSWORD%%"
+        auth:
+          enabled: true
+          aclUsers:
+            default:
+              password: "%%REDIS_PASSWORD%%"
     ```
 
 1. Run `helm upgrade` command with usual arguments, **new** `7.X.X` chart version

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -183,7 +183,7 @@ In this version, we've updated the following underlying dependencies, some of wh
     - `redis` replaced with `valkey` version bumped to `9.0.2`
 
 1. Stop Redis
-1. Update values.yaml by replacing the Redis config block with the following block. Strictly follow the indentation
+1. Update `values.yaml` with the replasing Redis config block with the next block. Strictly follow the indentation
   > [!tip]
   > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey)
 ```yaml

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -174,13 +174,13 @@ helm install my-release dial/dial -f values.yaml
 
 > [!CAUTION]
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
-> If you don't use embeded Redis, disregard the information below.
+> If you don't use embedded Redis, disregard the information below.
 > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
 >
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
 - `Redis` replaced with `Valkey`
-- `dial/dial-core` Helm chart version bumped from to `5.2.0` to `6.0.0`
+- `dial/dial-core` Helm chart version bumped from `5.2.0` to `6.0.0`
   - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
     - **Cluster → non‑clustered deployment**. We moved away from Redis Cluster. 
       For production you should review your HA/scale strategy and adjust accordingly.

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -183,24 +183,28 @@ In this version, we've updated the following underlying dependencies, some of wh
     - `redis` replaced with `valkey` version bumped to `9.0.2`
 
 1. Delete Redis-related config section in `values.yaml`
-```yaml
-  redis:
-    enabled: true
-    password: "%%REDIS_PASSWORD%%"
-```
-1. Adding `values.yaml` with the following  Valkey config section. Strictly follow the indentation
-  > [!tip]
-  > Strictly follow the indentation
-  > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey)
-```yaml
-valkey:
-  enabled: true
-  auth:
-    enabled: true
-    aclUsers:
-      default:
+
+    ```yaml
+      redis:
+        enabled: true
         password: "%%REDIS_PASSWORD%%"
-```
+    ```
+
+1. Adding `values.yaml` with the following  Valkey config section. Strictly follow the indentation
+    > [!tip]
+    > Strictly follow the indentation
+    > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey)
+
+    ```yaml
+    valkey:
+      enabled: true
+      auth:
+        enabled: true
+        aclUsers:
+          default:
+            password: "%%REDIS_PASSWORD%%"
+    ```
+
 1. Run `helm upgrade` command with usual arguments, **new** `7.X.X` chart version
 1. Manually delete the PVCs that remain after stopping Redis
 

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -180,6 +180,7 @@ helm install my-release dial/dial -f values.yaml
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
 
 - `Redis` replaced with `Valkey`
+- Install `Gateway API CRD`
 - `dial/dial-core` Helm chart version bumped from `5.2.0` to `6.0.0`
   - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
     - **Cluster → non‑clustered deployment**. We moved away from Redis Cluster.
@@ -187,6 +188,23 @@ In this version, we've updated the following underlying dependencies, some of wh
     - **Review memory / resources for Valkey**. Previous `redisCluster.*` values are ignored.
       Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.).
       This is not an obvious change without revisiting our values.
+
+1. If using the non-managed Kubernetes cluster, install `CRD Gateway API` and check `CRD Gateway API` with the following commands:
+
+    Install
+    ```shell
+    kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/standard-install.yaml
+    ```
+
+    Check
+    ```shell
+    kubectl get crd httproutes.gateway.networking.k8s.io
+
+    NAME                                   CREATED AT
+    httproutes.gateway.networking.k8s.io   %DATE%
+    ```
+
+1. If using a managed Kubernetes cluster, follow the service provider's instructions.
 
 1. If you use external Redis, replace Redis-related config section in `values.yaml`
 

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -178,7 +178,6 @@ helm install my-release dial/dial -f values.yaml
 
 > [!TIP]
 > Strictly follow the indentation.
-
 > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -1,6 +1,6 @@
 # dial
 
-![Version: 6.5.0](https://img.shields.io/badge/Version-6.5.0-informational?style=flat-square) ![AppVersion: 1.45.0](https://img.shields.io/badge/AppVersion-1.45.0-informational?style=flat-square)
+![Version: 7.0.0](https://img.shields.io/badge/Version-7.0.0-informational?style=flat-square) ![AppVersion: 1.45.0](https://img.shields.io/badge/AppVersion-1.45.0-informational?style=flat-square)
 
 Umbrella chart for DIAL solution
 
@@ -17,7 +17,7 @@ Kubernetes: `>=1.23.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | keycloak | 24.9.0 |
-| https://charts.dialx.ai | core(dial-core) | 5.2.0 |
+| https://charts.dialx.ai | core(dial-core) | 6.0.0 |
 | https://charts.dialx.ai | chat(dial-extension) | 3.1.1 |
 | https://charts.dialx.ai | themes(dial-extension) | 3.1.1 |
 | https://charts.dialx.ai | openai(dial-extension) | 3.1.1 |
@@ -169,6 +169,17 @@ helm install my-release dial/dial -f values.yaml
 | vertexai.resourcesPreset | string | `"small"` |  |
 
 ## Upgrading
+
+### To 7.0.0
+
+> [!CAUTION]
+> The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
+
+In this version, we've updated the following underlying dependencies, some of which require manual actions:
+- `Redis` replaced with `Valkey`
+- `dial/dial-core` Helm chart version bumped from to `5.2.0` to `6.0.0`
+  - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
+    - `redis` replaced with `valkey` version bumped to `9.0.2`
 
 ### To 6.0.0
 

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -174,7 +174,6 @@ helm install my-release dial/dial -f values.yaml
 
 > [!CAUTION]
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
-> If you don't use embedded Redis, disregard the information below.
 > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
 >
 

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -182,9 +182,15 @@ In this version, we've updated the following underlying dependencies, some of wh
   - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
     - `redis` replaced with `valkey` version bumped to `9.0.2`
 
-1. Stop Redis
-1. Update `values.yaml` with the replasing Redis config block with the next block. Strictly follow the indentation
+1. Delete Redis-related config section in `values.yaml`
+```yaml
+  redis:
+    enabled: true
+    password: "%%REDIS_PASSWORD%%"
+```
+1. Adding `values.yaml` with the following  Valkey config section. Strictly follow the indentation
   > [!tip]
+  > Strictly follow the indentation
   > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey)
 ```yaml
 valkey:

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -532,3 +532,56 @@ b) If using your own managed Kubernetes secret (`core.configuration.encryption.e
     ```console
     helm upgrade my-release dial/dial -f values.yaml
     ```
+
+## Valkey
+
+Core application uses a Valkey NoSQL database as a distributed cache. By default, the Helm chart deploys a [Valkey standalone](https://github.com/valkey-io/valkey-helm) instance as a dependency of the `dial-core` sub-chart with authentication disabled.
+
+It is **strongly recommended** to enable the authentication mechanism. An example of the configuration following the "least privilege" principles is provided below.
+
+```yaml
+core:
+  valkey:
+    enabled: true
+    auth:
+      enabled: true
+      usersExistingSecret: "dial-valkey-auth"
+      aclUsers:
+        default:
+          passwordKey: "default-password"
+          permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
+```
+
+### Configuring Valkey memory
+
+By default Valkey is allocated **2 Gi** of container memory and configured with a **2 G** `maxmemory` cap. Both values must be updated together when you need more cache capacity.
+
+> [!IMPORTANT]
+> Keep `valkeyConfig` `maxmemory` (e.g. `4G`) slightly below the container `resources.limits.memory` (e.g. `4Gi`) to leave headroom and avoid OOM kills. The intentional gap exists because Valkey `maxmemory` uses SI units while Kubernetes memory uses binary units.
+
+```yaml
+core:
+  valkey:
+    resources:
+      limits:
+        memory: 4Gi
+      requests:
+        memory: 4Gi
+    valkeyConfig: |
+      maxmemory 4G
+      maxmemory-policy volatile-lfu
+```
+
+### Use an external Valkey database
+
+You may want the application to connect to an external Valkey (or Redis-compatible) database rather than the one provided by the Helm chart — for example, when using a cloud-managed service such as AWS ElastiCache or Azure Cache for Redis. To do this, set `core.valkey.enabled` to `false` and specify the connection details:
+
+```yaml
+core:
+  valkey:
+    enabled: false
+  env:
+    aidial.redis.singleServerConfig.address: "redis://myexternalhost:6379"
+  secrets:
+    aidial.redis.singleServerConfig.password: "mypassword"
+```

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -175,7 +175,10 @@ helm install my-release dial/dial -f values.yaml
 > [!CAUTION]
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
 > If you don't use embeded Redis, disregard the information below.
+
+> [!TIP]
 > Strictly follow the indentation.
+
 > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -174,12 +174,29 @@ helm install my-release dial/dial -f values.yaml
 
 > [!CAUTION]
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
+> If you don't use embeded Redis, disregard the information below.
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
 - `Redis` replaced with `Valkey`
 - `dial/dial-core` Helm chart version bumped from to `5.2.0` to `6.0.0`
   - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
     - `redis` replaced with `valkey` version bumped to `9.0.2`
+
+1. Stop Redis
+1. Update `values.yaml` with the replasing Redis config block with the next block. Strictly follow the indentation
+  > [!tip]
+  > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey)
+```yaml
+valkey:
+  enabled: true
+  auth:
+    enabled: true
+    aclUsers:
+      default:
+        password: "%%REDIS_PASSWORD%%"
+```
+1. Run `helm upgrade` command with usual arguments, **new** `7.X.X` chart version
+1. Manually delete the PVCs that remain after stopping Redis
 
 ### To 6.0.0
 

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -208,10 +208,10 @@ In this version, we've updated the following underlying dependencies, some of wh
 
     From
     ```yaml
-      core:
-        redis:
-          enabled: true
-          password: "%%REDIS_PASSWORD%%"
+    core:
+      redis:
+        enabled: true
+        password: "%%REDIS_PASSWORD%%"
     ```
    
     To

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -179,18 +179,20 @@ helm install my-release dial/dial -f values.yaml
 >
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
+
 - `Redis` replaced with `Valkey`
 - `dial/dial-core` Helm chart version bumped from `5.2.0` to `6.0.0`
   - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
-    - **Cluster → non‑clustered deployment**. We moved away from Redis Cluster. 
+    - **Cluster → non‑clustered deployment**. We moved away from Redis Cluster.
       For production you should review your HA/scale strategy and adjust accordingly.
-    - **Review memory / resources for Valkey**. Previous `redisCluster.*` values are ignored. 
-      Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.). 
+    - **Review memory / resources for Valkey**. Previous `redisCluster.*` values are ignored.
+      Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.).
       This is not an obvious change without revisiting our values.
 
 1. If you use external Redis, replace Redis-related config section in `values.yaml`
 
     From
+
     ```yaml
     core:
       redis:
@@ -198,23 +200,28 @@ In this version, we've updated the following underlying dependencies, some of wh
     ```
 
     To
+
     ```yaml
     core:
       valkey:
         enabled: false
     ```
 
-1. If you use internal Redis, replace Redis-related config section in `values.yaml`
+1. If you use internal Redis, replace Redis-related config section in `values.yaml`.
 
-    From
+    **Option 1: inline password** (previously `core.redis.password`)
+
+    *Before:*
+
     ```yaml
     core:
       redis:
         enabled: true
         password: "%%REDIS_PASSWORD%%"
     ```
-   
-    To
+
+    *After:*
+
     ```yaml
     core:
       valkey:
@@ -225,6 +232,32 @@ In this version, we've updated the following underlying dependencies, some of wh
             default:
               permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
               password: "%%REDIS_PASSWORD%%"
+    ```
+
+    **Option 2: existing Kubernetes secret** (previously `core.redis.existingSecret` + `core.redis.existingSecretPasswordKey`)
+
+    *Before:*
+
+    ```yaml
+    core:
+      redis:
+        enabled: true
+        existingSecret: "my-redis-secret"
+        existingSecretPasswordKey: "redis-password"
+    ```
+
+    *After:*
+
+    ```yaml
+    core:
+      valkey:
+        enabled: true
+        auth:
+          enabled: true
+          usersExistingSecret: "my-redis-secret"
+          aclUsers:
+            default:
+              passwordKey: "redis-password"
     ```
 
 1. Run `helm upgrade` command with usual arguments, **new** `7.X.X` chart version

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -229,7 +229,6 @@ In this version, we've updated the following underlying dependencies, some of wh
           enabled: true
           aclUsers:
             default:
-              permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
               password: "%%REDIS_PASSWORD%%"
     ```
 

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -188,7 +188,7 @@ In this version, we've updated the following underlying dependencies, some of wh
       Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.). 
       This is not an obvious change without revisiting our values.
 
-1. If you use external Redis replace Redis-related config section in `values.yaml`
+1. If you use external Redis, replace Redis-related config section in `values.yaml`
 
     From
     ```yaml
@@ -204,17 +204,17 @@ In this version, we've updated the following underlying dependencies, some of wh
         enabled: false
     ```
 
-1. Delete Redis-related config section in `values.yaml`
+1. If you use internal Redis, replace Redis-related config section in `values.yaml`
 
+    From
     ```yaml
       core:
         redis:
           enabled: true
           password: "%%REDIS_PASSWORD%%"
     ```
-
-1. Adding `values.yaml` with the following Valkey config section. Strictly follow the indentation
-
+   
+    To
     ```yaml
     core:
       valkey:

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -168,6 +168,62 @@ helm install my-release dial/dial -f values.yaml
 | vertexai.readinessProbe.enabled | bool | `true` |  |
 | vertexai.resourcesPreset | string | `"small"` |  |
 
+## Valkey
+
+[Core](https://github.com/epam/ai-dial-core) application relies on in-memory NoSQL key-value database as a cache storage. Initially, the Helm chart was using [Redis](https://redis.io/) database, but starting from [version 7.0.0](#to-700), it is replaced with [Valkey](https://valkey.io/) - due to its enhancements and permissive license.
+
+By default, the Helm chart follows deploys `dial-core` sub-chart settings, which deploys Valkey in a [standalone](https://github.com/valkey-io/valkey-helm/tree/main/valkey#deployment-modes) mode (single instance, no replicas) with ACL-based authentication disabled.
+
+> [!warning]
+> It is **strongly recommended** to enable the authentication mechanism. An example of the configuration following the "least privilege" principles is provided below.
+
+```yaml
+core:
+  valkey:
+    enabled: true
+    auth:
+      enabled: true
+      usersExistingSecret: "dial-valkey-auth"
+      aclUsers:
+        default:
+          passwordKey: "default-password"
+          permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
+```
+
+### Adjusting memory
+
+By default Valkey itself is configured with `maxmemory 2G` (two gigabytes) and container granted `resources.limits.memory: 2Gi` (two gibibytes). This creates an intentional gap due to SI units in [application configuration](https://github.com/valkey-io/valkey/blob/cdf98a251e2dcb5772d5e544df73b931633834ba/valkey.conf#L8-L18) and binary units in Kubernetes specification, thus helps to avoid OOM kills.
+
+> [!IMPORTANT]
+> Both values must be updated in pair when you adjust cache capacity
+
+```yaml
+core:
+  valkey:
+    resources:
+      limits:
+        memory: 4Gi
+      requests:
+        memory: 4Gi
+    valkeyConfig: |
+      maxmemory 4G
+      maxmemory-policy volatile-lfu
+```
+
+### Use an external Valkey database
+
+You may want the application to connect to an external Valkey (or Redis-compatible) database rather than the one provided by the Helm chart - for example, when using a cloud-managed service such as AWS ElastiCache or Azure Cache for Redis. To do this, set `core.valkey.enabled` to `false` and specify the connection details:
+
+```yaml
+core:
+  valkey:
+    enabled: false
+  env:
+    aidial.redis.singleServerConfig.address: "redis://myexternalhost:6379"
+  secrets:
+    aidial.redis.singleServerConfig.password: "mypassword"
+```
+
 ## Upgrading
 
 ### To 7.0.0
@@ -175,40 +231,26 @@ helm install my-release dial/dial -f values.yaml
 > [!CAUTION]
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
 > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
->
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
 
-- `Redis` replaced with `Valkey`
 - `dial/dial-core` Helm chart version bumped from `5.2.0` to `6.0.0`
-  - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
-    - **Cluster → non‑clustered deployment**. We moved away from Redis Cluster.
-      For production you should review your HA/scale strategy and adjust accordingly.
-    - **Review memory / resources for Valkey**. Previous `redisCluster.*` values are ignored.
-      Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.).
-      This is not an obvious change without revisiting our values.
+  - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey` Helm chart
+    - [Redis](https://redis.io/) replaced with [Valkey](https://valkey.io/) database
+    - **Cluster** architecture (multiple master nodes, or shards) replaced with **Standalone** architecture (single node, no replicas). For production usage you should review your HA architecture/scale strategy and adjust accordingly.
 
-1. If using a managed Kubernetes cluster, follow the service provider's instructions.
+#### In-house deployment
 
-1. If you use external Redis, replace Redis-related config section in `values.yaml`
+1. Replace `core.redis` to `core.valkey` in `values.yaml`:
 
-    From
-
-    ```yaml
+    ```diff
     core:
-      redis:
-        enabled: false
+    -  redis:
+    +  valkey:
+        enabled: true
     ```
 
-    To
-
-    ```yaml
-    core:
-      valkey:
-        enabled: false
-    ```
-
-1. If you use internal Redis, replace Redis-related config section in `values.yaml`.
+1. Replace credentials configuration in `values.yaml`, based on your existing approach:
 
     **Option 1: inline password** (previously `core.redis.password`)
 
@@ -260,8 +302,20 @@ In this version, we've updated the following underlying dependencies, some of wh
               passwordKey: "redis-password"
     ```
 
+1. Ensure no other `core.redis` configuration blocks left in `values.yaml` or Helm `--set` arguments, otherwise migrate them according to [Valkey Helm chart documentation](https://github.com/valkey-io/valkey-helm/blob/main/valkey/values.yaml)
 1. Run `helm upgrade` command with usual arguments, **new** `7.X.X` chart version
-1. Manually delete the PVCs that remain after stopping Redis
+1. Manually delete the Redis-related PVCs
+
+#### External Valkey deployment
+
+1. Replace `core.redis` to `core.valkey` in `values.yaml`:
+
+    ```diff
+    core:
+    -  redis:
+    +  valkey:
+        enabled: false
+    ```
 
 ### To 6.0.0
 
@@ -532,56 +586,3 @@ b) If using your own managed Kubernetes secret (`core.configuration.encryption.e
     ```console
     helm upgrade my-release dial/dial -f values.yaml
     ```
-
-## Valkey
-
-Core application uses a Valkey NoSQL database as a distributed cache. By default, the Helm chart deploys a [Valkey standalone](https://github.com/valkey-io/valkey-helm) instance as a dependency of the `dial-core` sub-chart with authentication disabled.
-
-It is **strongly recommended** to enable the authentication mechanism. An example of the configuration following the "least privilege" principles is provided below.
-
-```yaml
-core:
-  valkey:
-    enabled: true
-    auth:
-      enabled: true
-      usersExistingSecret: "dial-valkey-auth"
-      aclUsers:
-        default:
-          passwordKey: "default-password"
-          permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
-```
-
-### Configuring Valkey memory
-
-By default Valkey is allocated **2 Gi** of container memory and configured with a **2 G** `maxmemory` cap. Both values must be updated together when you need more cache capacity.
-
-> [!IMPORTANT]
-> Keep `valkeyConfig` `maxmemory` (e.g. `4G`) slightly below the container `resources.limits.memory` (e.g. `4Gi`) to leave headroom and avoid OOM kills. The intentional gap exists because Valkey `maxmemory` uses SI units while Kubernetes memory uses binary units.
-
-```yaml
-core:
-  valkey:
-    resources:
-      limits:
-        memory: 4Gi
-      requests:
-        memory: 4Gi
-    valkeyConfig: |
-      maxmemory 4G
-      maxmemory-policy volatile-lfu
-```
-
-### Use an external Valkey database
-
-You may want the application to connect to an external Valkey (or Redis-compatible) database rather than the one provided by the Helm chart - for example, when using a cloud-managed service such as AWS ElastiCache or Azure Cache for Redis. To do this, set `core.valkey.enabled` to `false` and specify the connection details:
-
-```yaml
-core:
-  valkey:
-    enabled: false
-  env:
-    aidial.redis.singleServerConfig.address: "redis://myexternalhost:6379"
-  secrets:
-    aidial.redis.singleServerConfig.password: "mypassword"
-```

--- a/charts/dial/README.md
+++ b/charts/dial/README.md
@@ -183,7 +183,7 @@ In this version, we've updated the following underlying dependencies, some of wh
     - `redis` replaced with `valkey` version bumped to `9.0.2`
 
 1. Stop Redis
-1. Update `values.yaml` with the replasing Redis config block with the next block. Strictly follow the indentation
+1. Update values.yaml by replacing the Redis config block with the following block. Strictly follow the indentation
   > [!tip]
   > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey)
 ```yaml

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -79,7 +79,6 @@ helm install my-release dial/dial -f values.yaml
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
 
 - `Redis` replaced with `Valkey`
-- Install `Gateway API CRD`
 - `dial/dial-core` Helm chart version bumped from `5.2.0` to `6.0.0`
   - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
     - **Cluster → non‑clustered deployment**. We moved away from Redis Cluster.
@@ -88,20 +87,6 @@ In this version, we've updated the following underlying dependencies, some of wh
       Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.).
       This is not an obvious change without revisiting our values.
 
-1. If using the non-managed Kubernetes cluster, install `CRD Gateway API` and check `CRD Gateway API` with the following commands:
-
-    Install
-    ```shell
-    kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/standard-install.yaml
-    ```
-
-    Check
-    ```shell
-    kubectl get crd httproutes.gateway.networking.k8s.io
-
-    NAME                                   CREATED AT
-    httproutes.gateway.networking.k8s.io   %DATE%
-    ```
 
 1. If using a managed Kubernetes cluster, follow the service provider's instructions.
 
@@ -489,7 +474,7 @@ core:
 
 ### Use an external Valkey database
 
-You may want the application to connect to an external Valkey (or Redis-compatible) database rather than the one provided by the Helm chart — for example, when using a cloud-managed service such as AWS ElastiCache or Azure Cache for Redis. To do this, set `core.valkey.enabled` to `false` and specify the connection details:
+You may want the application to connect to an external Valkey (or Redis-compatible) database rather than the one provided by the Helm chart - for example, when using a cloud-managed service such as AWS ElastiCache or Azure Cache for Redis. To do this, set `core.valkey.enabled` to `false` and specify the connection details:
 
 ```yaml
 core:

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -82,24 +82,28 @@ In this version, we've updated the following underlying dependencies, some of wh
     - `redis` replaced with `valkey` version bumped to `9.0.2`
 
 1. Delete Redis-related config section in `values.yaml`
-```yaml
-  redis:
-    enabled: true
-    password: "%%REDIS_PASSWORD%%"
-```
+
+    ```yaml
+      redis:
+        enabled: true
+        password: "%%REDIS_PASSWORD%%"
+    ```
+
 1. Adding `values.yaml` with the following  Valkey config section. Strictly follow the indentation
   > [!tip]
   > Strictly follow the indentation
   > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey)
-```yaml
-valkey:
-  enabled: true
-  auth:
-    enabled: true
-    aclUsers:
-      default:
-        password: "%%REDIS_PASSWORD%%"
-```
+
+    ```yaml
+    valkey:
+      enabled: true
+      auth:
+        enabled: true
+        aclUsers:
+          default:
+            password: "%%REDIS_PASSWORD%%"
+    ```
+
 1. Run `helm upgrade` command with usual arguments, **new** `7.X.X` chart version
 1. Manually delete the PVCs that remain after stopping Redis
 

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -69,6 +69,17 @@ helm install my-release dial/dial -f values.yaml
 
 ## Upgrading
 
+### To 7.0.0
+
+> [!CAUTION]
+> The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
+
+In this version, we've updated the following underlying dependencies, some of which require manual actions:
+- `Redis` replaced with `Valkey`
+- `dial/dial-core` Helm chart version bumped from to `5.2.0` to `6.0.0`
+  - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
+    - `redis` replaced with `valkey` version bumped to `9.0.2`
+
 ### To 6.0.0
 
 > [!CAUTION]
@@ -83,7 +94,7 @@ In this version, we've updated the following underlying dependencies, some of wh
     - `postgresql` version bumped from `17.2.0` to `17.6.0`
 - `dial/dial-core` Helm chart version bumped from to `4.3.1` to `5.1.1`
   - `bitnami/redis-cluster` Helm chart version bumped from to `11.4.0` to `13.0.4`
-    - `redis` version bumped from `7.4.2` to `8.2.1`
+    - `redis` version bumped from `7.4.2` to `8.2.1` 
 - `dial/dial-extension` Helm charts version bumped from to `1.3.3` to `2.2.1`
 - `bitnami/common` Helm chart version bumped from to `2.29.0` to `2.31.4`
 

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -75,21 +75,23 @@ helm install my-release dial/dial -f values.yaml
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
 > If you don't use embedded Redis, disregard the information below.
 > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
-> 
+>
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
+
 - `Redis` replaced with `Valkey`
 - `dial/dial-core` Helm chart version bumped from `5.2.0` to `6.0.0`
   - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
-    - **Cluster → non‑clustered deployment**. We moved away from Redis Cluster.  
+    - **Cluster → non‑clustered deployment**. We moved away from Redis Cluster.
       For production you should review your HA/scale strategy and adjust accordingly.
-    - **Review memory / resources for Valkey**. Previous `redisCluster.*` values are ignored.  
-      Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.).  
+    - **Review memory / resources for Valkey**. Previous `redisCluster.*` values are ignored.
+      Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.).
       This is not an obvious change without revisiting our values.
 
 1. If you use external Redis, replace Redis-related config section in `values.yaml`
 
     From
+
     ```yaml
     core:
       redis:
@@ -97,23 +99,28 @@ In this version, we've updated the following underlying dependencies, some of wh
     ```
 
     To
+
     ```yaml
     core:
       valkey:
         enabled: false
     ```
 
-1. If you use internal Redis, replace Redis-related config section in `values.yaml`
+1. If you use internal Redis, replace Redis-related config section in `values.yaml`.
 
-    From
+    **Option 1: inline password** (previously `core.redis.password`)
+
+    *Before:*
+
     ```yaml
     core:
       redis:
         enabled: true
         password: "%%REDIS_PASSWORD%%"
     ```
-    
-    To
+
+    *After:*
+
     ```yaml
     core:
       valkey:
@@ -124,6 +131,32 @@ In this version, we've updated the following underlying dependencies, some of wh
             default:
               permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
               password: "%%REDIS_PASSWORD%%"
+    ```
+
+    **Option 2: existing Kubernetes secret** (previously `core.redis.existingSecret` + `core.redis.existingSecretPasswordKey`)
+
+    *Before:*
+
+    ```yaml
+    core:
+      redis:
+        enabled: true
+        existingSecret: "my-redis-secret"
+        existingSecretPasswordKey: "redis-password"
+    ```
+
+    *After:*
+
+    ```yaml
+    core:
+      valkey:
+        enabled: true
+        auth:
+          enabled: true
+          usersExistingSecret: "my-redis-secret"
+          aclUsers:
+            default:
+              passwordKey: "redis-password"
     ```
 
 1. Run `helm upgrade` command with usual arguments, **new** `7.X.X` chart version
@@ -143,7 +176,7 @@ In this version, we've updated the following underlying dependencies, some of wh
     - `postgresql` version bumped from `17.2.0` to `17.6.0`
 - `dial/dial-core` Helm chart version bumped from to `4.3.1` to `5.1.1`
   - `bitnami/redis-cluster` Helm chart version bumped from to `11.4.0` to `13.0.4`
-    - `redis` version bumped from `7.4.2` to `8.2.1` 
+    - `redis` version bumped from `7.4.2` to `8.2.1`
 - `dial/dial-extension` Helm charts version bumped from to `1.3.3` to `2.2.1`
 - `bitnami/common` Helm chart version bumped from to `2.29.0` to `2.31.4`
 

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -74,7 +74,10 @@ helm install my-release dial/dial -f values.yaml
 > [!CAUTION]
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
 > If you don't use embeded Redis, disregard the information below.
+
+> [!TIP]
 > Strictly follow the indentation.
+
 > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -107,10 +107,10 @@ In this version, we've updated the following underlying dependencies, some of wh
 
     From
     ```yaml
-      core:
-        redis:
-          enabled: true
-          password: "%%REDIS_PASSWORD%%"
+    core:
+      redis:
+        enabled: true
+        password: "%%REDIS_PASSWORD%%"
     ```
     
     To

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -146,6 +146,7 @@ In this version, we've updated the following underlying dependencies, some of wh
     core:
     -  redis:
     +  valkey:
+        enabled: true
     ```
 
 1. Replace credentials configuration in `values.yaml`, based on your existing approach:
@@ -212,9 +213,8 @@ In this version, we've updated the following underlying dependencies, some of wh
     core:
     -  redis:
     +  valkey:
+        enabled: false
     ```
-
-1. <!-- TODO -->
 
 ### To 6.0.0
 

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -87,9 +87,7 @@ In this version, we've updated the following underlying dependencies, some of wh
       Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.).  
       This is not an obvious change without revisiting our values.
 
-> [!TIP]
-> If you don't use external Redis, disregard the information below and proceed to the next step.
-1. Replace Redis-related config section in `values.yaml`
+1. If you use external Redis replace Redis-related config section in `values.yaml`
 
     From
     ```yaml
@@ -114,7 +112,7 @@ In this version, we've updated the following underlying dependencies, some of wh
           password: "%%REDIS_PASSWORD%%"
     ```
 
-1. Adding `values.yaml` with the following  Valkey config section. Strictly follow the indentation
+1. Adding `values.yaml` with the following Valkey config section. Strictly follow the indentation
 
     ```yaml
     core:
@@ -124,6 +122,7 @@ In this version, we've updated the following underlying dependencies, some of wh
           enabled: true
           aclUsers:
             default:
+              permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
               password: "%%REDIS_PASSWORD%%"
     ```
 

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -87,7 +87,7 @@ In this version, we've updated the following underlying dependencies, some of wh
       Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.).  
       This is not an obvious change without revisiting our values.
 
-1. If you use external Redis replace Redis-related config section in `values.yaml`
+1. If you use external Redis, replace Redis-related config section in `values.yaml`
 
     From
     ```yaml
@@ -103,17 +103,17 @@ In this version, we've updated the following underlying dependencies, some of wh
         enabled: false
     ```
 
-1. Delete Redis-related config section in `values.yaml`
+1. If you use internal Redis, replace Redis-related config section in `values.yaml`
 
+    From
     ```yaml
       core:
         redis:
           enabled: true
           password: "%%REDIS_PASSWORD%%"
     ```
-
-1. Adding `values.yaml` with the following Valkey config section. Strictly follow the indentation
-
+    
+    To
     ```yaml
     core:
       valkey:

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -67,6 +67,62 @@ helm install my-release dial/dial -f values.yaml
 
 {{ template "chart.valuesSection" . }}
 
+## Valkey
+
+[Core](https://github.com/epam/ai-dial-core) application relies on in-memory NoSQL key-value database as a cache storage. Initially, the Helm chart was using [Redis](https://redis.io/) database, but starting from [version 7.0.0](#to-700), it is replaced with [Valkey](https://valkey.io/) - due to its enhancements and permissive license.
+
+By default, the Helm chart follows deploys `dial-core` sub-chart settings, which deploys Valkey in a [standalone](https://github.com/valkey-io/valkey-helm/tree/main/valkey#deployment-modes) mode (single instance, no replicas) with ACL-based authentication disabled.
+
+> [!warning]
+> It is **strongly recommended** to enable the authentication mechanism. An example of the configuration following the "least privilege" principles is provided below.
+
+```yaml
+core:
+  valkey:
+    enabled: true
+    auth:
+      enabled: true
+      usersExistingSecret: "dial-valkey-auth"
+      aclUsers:
+        default:
+          passwordKey: "default-password"
+          permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
+```
+
+### Adjusting memory
+
+By default Valkey itself is configured with `maxmemory 2G` (two gigabytes) and container granted `resources.limits.memory: 2Gi` (two gibibytes). This creates an intentional gap due to SI units in [application configuration](https://github.com/valkey-io/valkey/blob/cdf98a251e2dcb5772d5e544df73b931633834ba/valkey.conf#L8-L18) and binary units in Kubernetes specification, thus helps to avoid OOM kills.
+
+> [!IMPORTANT]
+> Both values must be updated in pair when you adjust cache capacity
+
+```yaml
+core:
+  valkey:
+    resources:
+      limits:
+        memory: 4Gi
+      requests:
+        memory: 4Gi
+    valkeyConfig: |
+      maxmemory 4G
+      maxmemory-policy volatile-lfu
+```
+
+### Use an external Valkey database
+
+You may want the application to connect to an external Valkey (or Redis-compatible) database rather than the one provided by the Helm chart - for example, when using a cloud-managed service such as AWS ElastiCache or Azure Cache for Redis. To do this, set `core.valkey.enabled` to `false` and specify the connection details:
+
+```yaml
+core:
+  valkey:
+    enabled: false
+  env:
+    aidial.redis.singleServerConfig.address: "redis://myexternalhost:6379"
+  secrets:
+    aidial.redis.singleServerConfig.password: "mypassword"
+```
+
 ## Upgrading
 
 ### To 7.0.0
@@ -74,41 +130,25 @@ helm install my-release dial/dial -f values.yaml
 > [!CAUTION]
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
 > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
->
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
 
-- `Redis` replaced with `Valkey`
 - `dial/dial-core` Helm chart version bumped from `5.2.0` to `6.0.0`
-  - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
-    - **Cluster → non‑clustered deployment**. We moved away from Redis Cluster.
-      For production you should review your HA/scale strategy and adjust accordingly.
-    - **Review memory / resources for Valkey**. Previous `redisCluster.*` values are ignored.
-      Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.).
-      This is not an obvious change without revisiting our values.
+  - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey` Helm chart
+    - [Redis](https://redis.io/) replaced with [Valkey](https://valkey.io/) database
+    - **Cluster** architecture (multiple master nodes, or shards) replaced with **Standalone** architecture (single node, no replicas). For production usage you should review your HA architecture/scale strategy and adjust accordingly.
 
+#### In-house deployment
 
-1. If using a managed Kubernetes cluster, follow the service provider's instructions.
+1. Replace `core.redis` to `core.valkey` in `values.yaml`:
 
-1. If you use external Redis, replace Redis-related config section in `values.yaml`
-
-    From
-
-    ```yaml
+    ```diff
     core:
-      redis:
-        enabled: false
+    -  redis:
+    +  valkey:
     ```
 
-    To
-
-    ```yaml
-    core:
-      valkey:
-        enabled: false
-    ```
-
-1. If you use internal Redis, replace Redis-related config section in `values.yaml`.
+1. Replace credentials configuration in `values.yaml`, based on your existing approach:
 
     **Option 1: inline password** (previously `core.redis.password`)
 
@@ -160,8 +200,21 @@ In this version, we've updated the following underlying dependencies, some of wh
               passwordKey: "redis-password"
     ```
 
+1. Ensure no other `core.redis` configuration blocks left in `values.yaml` or Helm `--set` arguments, otherwise migrate them according to [Valkey Helm chart documentation](https://github.com/valkey-io/valkey-helm/blob/main/valkey/values.yaml)
 1. Run `helm upgrade` command with usual arguments, **new** `7.X.X` chart version
-1. Manually delete the PVCs that remain after stopping Redis
+1. Manually delete the Redis-related PVCs
+
+#### External Valkey deployment
+
+1. Replace `core.redis` to `core.valkey` in `values.yaml`:
+
+    ```diff
+    core:
+    -  redis:
+    +  valkey:
+    ```
+
+1. <!-- TODO -->
 
 ### To 6.0.0
 
@@ -432,56 +485,3 @@ b) If using your own managed Kubernetes secret (`core.configuration.encryption.e
     ```console
     helm upgrade my-release dial/dial -f values.yaml
     ```
-
-## Valkey
-
-Core application uses a Valkey NoSQL database as a distributed cache. By default, the Helm chart deploys a [Valkey standalone](https://github.com/valkey-io/valkey-helm) instance as a dependency of the `dial-core` sub-chart with authentication disabled.
-
-It is **strongly recommended** to enable the authentication mechanism. An example of the configuration following the "least privilege" principles is provided below.
-
-```yaml
-core:
-  valkey:
-    enabled: true
-    auth:
-      enabled: true
-      usersExistingSecret: "dial-valkey-auth"
-      aclUsers:
-        default:
-          passwordKey: "default-password"
-          permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
-```
-
-### Configuring Valkey memory
-
-By default Valkey is allocated **2 Gi** of container memory and configured with a **2 G** `maxmemory` cap. Both values must be updated together when you need more cache capacity.
-
-> [!IMPORTANT]
-> Keep `valkeyConfig` `maxmemory` (e.g. `4G`) slightly below the container `resources.limits.memory` (e.g. `4Gi`) to leave headroom and avoid OOM kills. The intentional gap exists because Valkey `maxmemory` uses SI units while Kubernetes memory uses binary units.
-
-```yaml
-core:
-  valkey:
-    resources:
-      limits:
-        memory: 4Gi
-      requests:
-        memory: 4Gi
-    valkeyConfig: |
-      maxmemory 4G
-      maxmemory-policy volatile-lfu
-```
-
-### Use an external Valkey database
-
-You may want the application to connect to an external Valkey (or Redis-compatible) database rather than the one provided by the Helm chart - for example, when using a cloud-managed service such as AWS ElastiCache or Azure Cache for Redis. To do this, set `core.valkey.enabled` to `false` and specify the connection details:
-
-```yaml
-core:
-  valkey:
-    enabled: false
-  env:
-    aidial.redis.singleServerConfig.address: "redis://myexternalhost:6379"
-  secrets:
-    aidial.redis.singleServerConfig.password: "mypassword"
-```

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -79,6 +79,7 @@ helm install my-release dial/dial -f values.yaml
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
 
 - `Redis` replaced with `Valkey`
+- Install `Gateway API CRD`
 - `dial/dial-core` Helm chart version bumped from `5.2.0` to `6.0.0`
   - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
     - **Cluster → non‑clustered deployment**. We moved away from Redis Cluster.
@@ -86,6 +87,23 @@ In this version, we've updated the following underlying dependencies, some of wh
     - **Review memory / resources for Valkey**. Previous `redisCluster.*` values are ignored.
       Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.).
       This is not an obvious change without revisiting our values.
+
+1. If using the non-managed Kubernetes cluster, install `CRD Gateway API` and check `CRD Gateway API` with the following commands:
+
+    Install
+    ```shell
+    kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/standard-install.yaml
+    ```
+
+    Check
+    ```shell
+    kubectl get crd httproutes.gateway.networking.k8s.io
+
+    NAME                                   CREATED AT
+    httproutes.gateway.networking.k8s.io   %DATE%
+    ```
+
+1. If using a managed Kubernetes cluster, follow the service provider's instructions.
 
 1. If you use external Redis, replace Redis-related config section in `values.yaml`
 

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -77,7 +77,6 @@ helm install my-release dial/dial -f values.yaml
 
 > [!TIP]
 > Strictly follow the indentation.
-
 > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -90,9 +90,9 @@ In this version, we've updated the following underlying dependencies, some of wh
     ```
 
 1. Adding `values.yaml` with the following  Valkey config section. Strictly follow the indentation
-  > [!tip]
-  > Strictly follow the indentation
-  > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey)
+    > [!tip]
+    > Strictly follow the indentation
+    > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey)
 
     ```yaml
     valkey:

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -431,3 +431,56 @@ b) If using your own managed Kubernetes secret (`core.configuration.encryption.e
     ```console
     helm upgrade my-release dial/dial -f values.yaml
     ```
+
+## Valkey
+
+Core application uses a Valkey NoSQL database as a distributed cache. By default, the Helm chart deploys a [Valkey standalone](https://github.com/valkey-io/valkey-helm) instance as a dependency of the `dial-core` sub-chart with authentication disabled.
+
+It is **strongly recommended** to enable the authentication mechanism. An example of the configuration following the "least privilege" principles is provided below.
+
+```yaml
+core:
+  valkey:
+    enabled: true
+    auth:
+      enabled: true
+      usersExistingSecret: "dial-valkey-auth"
+      aclUsers:
+        default:
+          passwordKey: "default-password"
+          permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
+```
+
+### Configuring Valkey memory
+
+By default Valkey is allocated **2 Gi** of container memory and configured with a **2 G** `maxmemory` cap. Both values must be updated together when you need more cache capacity.
+
+> [!IMPORTANT]
+> Keep `valkeyConfig` `maxmemory` (e.g. `4G`) slightly below the container `resources.limits.memory` (e.g. `4Gi`) to leave headroom and avoid OOM kills. The intentional gap exists because Valkey `maxmemory` uses SI units while Kubernetes memory uses binary units.
+
+```yaml
+core:
+  valkey:
+    resources:
+      limits:
+        memory: 4Gi
+      requests:
+        memory: 4Gi
+    valkeyConfig: |
+      maxmemory 4G
+      maxmemory-policy volatile-lfu
+```
+
+### Use an external Valkey database
+
+You may want the application to connect to an external Valkey (or Redis-compatible) database rather than the one provided by the Helm chart — for example, when using a cloud-managed service such as AWS ElastiCache or Azure Cache for Redis. To do this, set `core.valkey.enabled` to `false` and specify the connection details:
+
+```yaml
+core:
+  valkey:
+    enabled: false
+  env:
+    aidial.redis.singleServerConfig.address: "redis://myexternalhost:6379"
+  secrets:
+    aidial.redis.singleServerConfig.password: "mypassword"
+```

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -73,12 +73,29 @@ helm install my-release dial/dial -f values.yaml
 
 > [!CAUTION]
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
+> If you don't use embeded Redis, disregard the information below.
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
 - `Redis` replaced with `Valkey`
 - `dial/dial-core` Helm chart version bumped from to `5.2.0` to `6.0.0`
   - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
     - `redis` replaced with `valkey` version bumped to `9.0.2`
+
+1. Stop Redis
+1. Update `values.yaml` with the replasing Redis config block with the next block. Strictly follow the indentation
+  > [!tip]
+  > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey)
+```yaml
+valkey:
+  enabled: true
+  auth:
+    enabled: true
+    aclUsers:
+      default:
+        password: "%%REDIS_PASSWORD%%"
+```
+1. Run `helm upgrade` command with usual arguments, **new** `7.X.X` chart version
+1. Manually delete the PVCs that remain after stopping Redis
 
 ### To 6.0.0
 

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -74,35 +74,57 @@ helm install my-release dial/dial -f values.yaml
 > [!CAUTION]
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
 > If you don't use embeded Redis, disregard the information below.
-
-> [!TIP]
-> Strictly follow the indentation.
 > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
+> 
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
 - `Redis` replaced with `Valkey`
 - `dial/dial-core` Helm chart version bumped from to `5.2.0` to `6.0.0`
   - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
-    - `redis` replaced with `valkey` version bumped to `9.0.2`
+    - **Cluster → non‑clustered deployment**. We moved away from Redis Cluster.  
+      For production you should review your HA/scale strategy and adjust accordingly.
+    - **Review memory / resources for Valkey**. Previous `redisCluster.*` values are ignored.  
+      Update Valkey settings in `values.yaml` (e.g. `valkey.resources`, `valkey.primary.resources`, `valkey.config.maxmemory`, persistence, etc.).  
+      This is not an obvious change without revisiting our values.
+
+> [!TIP]
+> If you don't use external Redis, disregard the information below and proceed to the next step.
+1. Replace Redis-related config section in `values.yaml`
+
+    From
+    ```yaml
+    core:
+      redis:
+        enabled: false
+    ```
+
+    To
+    ```yaml
+    core:
+      valkey:
+        enabled: false
+    ```
 
 1. Delete Redis-related config section in `values.yaml`
 
     ```yaml
-      redis:
-        enabled: true
-        password: "%%REDIS_PASSWORD%%"
+      core:
+        redis:
+          enabled: true
+          password: "%%REDIS_PASSWORD%%"
     ```
 
 1. Adding `values.yaml` with the following  Valkey config section. Strictly follow the indentation
 
     ```yaml
-    valkey:
-      enabled: true
-      auth:
+    core:
+      valkey:
         enabled: true
-        aclUsers:
-          default:
-            password: "%%REDIS_PASSWORD%%"
+        auth:
+          enabled: true
+          aclUsers:
+            default:
+              password: "%%REDIS_PASSWORD%%"
     ```
 
 1. Run `helm upgrade` command with usual arguments, **new** `7.X.X` chart version

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -73,7 +73,6 @@ helm install my-release dial/dial -f values.yaml
 
 > [!CAUTION]
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
-> If you don't use embedded Redis, disregard the information below.
 > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
 >
 

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -128,7 +128,6 @@ In this version, we've updated the following underlying dependencies, some of wh
           enabled: true
           aclUsers:
             default:
-              permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
               password: "%%REDIS_PASSWORD%%"
     ```
 

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -74,6 +74,8 @@ helm install my-release dial/dial -f values.yaml
 > [!CAUTION]
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
 > If you don't use embeded Redis, disregard the information below.
+> Strictly follow the indentation.
+> Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
 - `Redis` replaced with `Valkey`
@@ -90,9 +92,6 @@ In this version, we've updated the following underlying dependencies, some of wh
     ```
 
 1. Adding `values.yaml` with the following  Valkey config section. Strictly follow the indentation
-    > [!tip]
-    > Strictly follow the indentation
-    > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey)
 
     ```yaml
     valkey:

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -81,9 +81,15 @@ In this version, we've updated the following underlying dependencies, some of wh
   - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
     - `redis` replaced with `valkey` version bumped to `9.0.2`
 
-1. Stop Redis
-1. Update `values.yaml` with the replasing Redis config block with the next block. Strictly follow the indentation
+1. Delete Redis-related config section in `values.yaml`
+```yaml
+  redis:
+    enabled: true
+    password: "%%REDIS_PASSWORD%%"
+```
+1. Adding `values.yaml` with the following  Valkey config section. Strictly follow the indentation
   > [!tip]
+  > Strictly follow the indentation
   > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey)
 ```yaml
 valkey:

--- a/charts/dial/README.md.gotmpl
+++ b/charts/dial/README.md.gotmpl
@@ -73,13 +73,13 @@ helm install my-release dial/dial -f values.yaml
 
 > [!CAUTION]
 > The upgrade includes **BREAKING CHANGES** and require **MANUAL ACTIONS**.
-> If you don't use embeded Redis, disregard the information below.
+> If you don't use embedded Redis, disregard the information below.
 > Find detailed information about this Valkey configuration block in [Valkey README.md](https://github.com/valkey-io/valkey-helm/tree/main/valkey).
 > 
 
 In this version, we've updated the following underlying dependencies, some of which require manual actions:
 - `Redis` replaced with `Valkey`
-- `dial/dial-core` Helm chart version bumped from to `5.2.0` to `6.0.0`
+- `dial/dial-core` Helm chart version bumped from `5.2.0` to `6.0.0`
   - `bitnami/redis-cluster` Helm chart replaced with `valkey/valkey`
     - **Cluster → non‑clustered deployment**. We moved away from Redis Cluster.  
       For production you should review your HA/scale strategy and adjust accordingly.

--- a/charts/dial/examples/aws/complete/README.md
+++ b/charts/dial/examples/aws/complete/README.md
@@ -24,7 +24,7 @@
   - [Vertex AI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 - [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview)
   - [OpenAI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/openai-model-deployment)
-- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic.claude-opus-4-8` model deployed:
+- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `global.anthropic.claude-opus-4-8` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/aws/complete/README.md
+++ b/charts/dial/examples/aws/complete/README.md
@@ -24,7 +24,7 @@
   - [Vertex AI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 - [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview)
   - [OpenAI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/openai-model-deployment)
-- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic.claude-v1` model deployed:
+- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic-chat-latest` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/aws/complete/README.md
+++ b/charts/dial/examples/aws/complete/README.md
@@ -68,7 +68,6 @@ For authenticaConfiguring authentication provider, encrypted secrets, model usag
     - Replace `%%AWS_COGNITO_REGION%%` - aws region where resides Cognito pool e.g. `us-east-1`
     - Replace `%%AWS_COGNITO_ID%%` with AWS Cognito pool id e.g. `us-east-1_AbcD0efGh`
     - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
-    - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - Replace `%%AWS_CERTIFICATE_ARN%%` with associated ACM certificate arn e.g. `arn:aws:acm:us-east-1:123456789012:certificate/1234567a-b123-4567-8c9d-123456789012`
     - Replace `%%AUTH_COGNITO_HOST%%` with AWS Cognito host like `https://cognito-idp.us-east-1.amazonaws.com/us-east-1_AbcD0efGh`
     - Replace `%%AUTH_COGNITO_CLIENT_ID%%` with AWS Cognito client ID [link](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-client-apps.html)

--- a/charts/dial/examples/aws/complete/README.md
+++ b/charts/dial/examples/aws/complete/README.md
@@ -67,7 +67,8 @@ For authenticaConfiguring authentication provider, encrypted secrets, model usag
 1. Copy [values.yaml](values.yaml) file to your working directory and fill in missing values:
     - Replace `%%AWS_COGNITO_REGION%%` - aws region where resides Cognito pool e.g. `us-east-1`
     - Replace `%%AWS_COGNITO_ID%%` with AWS Cognito pool id e.g. `us-east-1_AbcD0efGh`
-    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with appropriate endpoint from [prerequisites](#prerequisites)
+    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `https://not-a-real-endpoint.openai.azure.com/openai/v1/responses`
+    - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - Replace `%%AWS_CERTIFICATE_ARN%%` with associated ACM certificate arn e.g. `arn:aws:acm:us-east-1:123456789012:certificate/1234567a-b123-4567-8c9d-123456789012`
     - Replace `%%AUTH_COGNITO_HOST%%` with AWS Cognito host like `https://cognito-idp.us-east-1.amazonaws.com/us-east-1_AbcD0efGh`
     - Replace `%%AUTH_COGNITO_CLIENT_ID%%` with AWS Cognito client ID [link](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-client-apps.html)

--- a/charts/dial/examples/aws/complete/README.md
+++ b/charts/dial/examples/aws/complete/README.md
@@ -73,6 +73,7 @@ For authenticaConfiguring authentication provider, encrypted secrets, model usag
     - Replace `%%AUTH_COGNITO_SECRET%%` with Cognito secret [link](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-client-apps.html)
     - Replace `%%AWS_ELASTICACHE_ENDPOINT%%` with AWS ElastiCashe like `'["rediss://clustercfg.yourEndpoint.cache.amazonaws.com:6379"]'`
     - Replace `%%GCP_PROJECT_ID%%` - with GCP Project id
+    - Replace `%%GCP_REGION%%` with GCP Region e.g. `us-east1`
     - Replace `%%GCP_SERVICE_ACCOUNT_AUDIENCE%%` with audience value from %%GCP_WORKLOAD_IDENTITY_CREDS%%
     - Replace `%%GCP_WORKLOAD_IDENTITY_CREDS%%` - with GCP Workload Identity
     - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
@@ -108,7 +109,6 @@ For authenticaConfiguring authentication provider, encrypted secrets, model usag
     - Replace `%%AWS_ELASTICACHE_CLUSTERNAME%%` with AWS ElastiCache cluster name [prerequisites](#prerequisites)
     - Replace `%%AWS_ELASTICACHE_IS_SERVERLES%%` with AWS ElastiCache serverless flag [prerequisites](#prerequisites)
     - Replace `%%AWS_BEDROCK_ROLE_ARN%%` with bedrock AWS role ARN from [prerequisites](#prerequisites)
-    - Replace `%%AWS_BEDROCK_REGION%%` with bedrock region from [prerequisites](#prerequisites)
     - It's assumed you've configured **external-dns** and **aws-load-balancer-controller** beforehand, so replace `%%DOMAIN%%` with your domain name, e.g. `example.com`, and `%%AWS_CERTIFICATE_ARN%%` with your AWS ACM certificate ARN, e.g. `arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012`
 
 1. Install `dial` helm chart in created namespace, applying custom values file:

--- a/charts/dial/examples/aws/complete/README.md
+++ b/charts/dial/examples/aws/complete/README.md
@@ -13,6 +13,7 @@
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
 - [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/installation/) installed in the cluster
+- [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/installation/) installed in the cluster
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) installed and configured
 - [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html) installed and configured

--- a/charts/dial/examples/aws/complete/README.md
+++ b/charts/dial/examples/aws/complete/README.md
@@ -67,7 +67,7 @@ For authenticaConfiguring authentication provider, encrypted secrets, model usag
 1. Copy [values.yaml](values.yaml) file to your working directory and fill in missing values:
     - Replace `%%AWS_COGNITO_REGION%%` - aws region where resides Cognito pool e.g. `us-east-1`
     - Replace `%%AWS_COGNITO_ID%%` with AWS Cognito pool id e.g. `us-east-1_AbcD0efGh`
-    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `https://not-a-real-endpoint.openai.azure.com/openai/v1/responses`
+    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
     - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - Replace `%%AWS_CERTIFICATE_ARN%%` with associated ACM certificate arn e.g. `arn:aws:acm:us-east-1:123456789012:certificate/1234567a-b123-4567-8c9d-123456789012`
     - Replace `%%AUTH_COGNITO_HOST%%` with AWS Cognito host like `https://cognito-idp.us-east-1.amazonaws.com/us-east-1_AbcD0efGh`

--- a/charts/dial/examples/aws/complete/README.md
+++ b/charts/dial/examples/aws/complete/README.md
@@ -20,6 +20,7 @@
 - [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
 - [Amazon Cognito](https://docs.dialx.ai/tutorials/devops/auth-and-access-control/configure-idps/cognito)
 - [Amazon ElastiCache for Redis with user configured in IAM authentication mode](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth-iam.html)
+- [AWS Bedrock Regional availability by models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-region-compatibility.html)
 - [Google Vertex AI](https://cloud.google.com/vertex-ai/docs/start/introduction-unified-platform)
   - [Vertex AI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 - [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview)

--- a/charts/dial/examples/aws/complete/README.md
+++ b/charts/dial/examples/aws/complete/README.md
@@ -76,7 +76,6 @@ For authenticaConfiguring authentication provider, encrypted secrets, model usag
     - Replace `%%GCP_REGION%%` with GCP Region e.g. `us-east1`
     - Replace `%%GCP_SERVICE_ACCOUNT_AUDIENCE%%` with audience value from %%GCP_WORKLOAD_IDENTITY_CREDS%%
     - Replace `%%GCP_WORKLOAD_IDENTITY_CREDS%%` - with GCP Workload Identity
-    - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
       ```json
           {

--- a/charts/dial/examples/aws/complete/README.md
+++ b/charts/dial/examples/aws/complete/README.md
@@ -24,7 +24,7 @@
   - [Vertex AI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 - [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview)
   - [OpenAI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/openai-model-deployment)
-- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic-chat-latest` model deployed:
+- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic.claude-opus-4-8` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/aws/complete/README.md
+++ b/charts/dial/examples/aws/complete/README.md
@@ -19,7 +19,7 @@
 - [GCP Workload Identity Federation with Kubernetes](https://cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes#eks) configured
 - [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
 - [Amazon Cognito](https://docs.dialx.ai/tutorials/devops/auth-and-access-control/configure-idps/cognito)
-- [Amazon ElastiCache for Redis with user configured in IAM authentication mode](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth-iam.html)
+- [Amazon ElastiCache with user configured in IAM authentication mode](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth-iam.html)
 - [Google Vertex AI](https://cloud.google.com/vertex-ai/docs/start/introduction-unified-platform)
   - [Vertex AI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 - [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview)
@@ -71,7 +71,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AUTH_COGNITO_HOST%%` with AWS Cognito host like `https://cognito-idp.us-east-1.amazonaws.com/us-east-1_AbcD0efGh`
     - Replace `%%AUTH_COGNITO_CLIENT_ID%%` with AWS Cognito client ID [link](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-client-apps.html)
     - Replace `%%AUTH_COGNITO_SECRET%%` with Cognito secret [link](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-client-apps.html)
-    - Replace `%%AWS_ELASTICACHE_ENDPOINT%%` with AWS ElastiCashe like `'["rediss://clustercfg.yourEndpoint.cache.amazonaws.com:6379"]'`
+    - Replace `%%AWS_ELASTICACHE_ENDPOINT%%` with AWS ElastiCache like `'["rediss://clustercfg.yourEndpoint.cache.amazonaws.com:6379"]'`
     - Replace `%%GCP_PROJECT_ID%%` - with GCP Project id
     - Replace `%%GCP_REGION%%` with GCP Region e.g. `us-east1`
     - Replace `%%GCP_SERVICE_ACCOUNT_AUDIENCE%%` with audience value from %%GCP_WORKLOAD_IDENTITY_CREDS%%

--- a/charts/dial/examples/aws/complete/README.md
+++ b/charts/dial/examples/aws/complete/README.md
@@ -13,7 +13,6 @@
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
 - [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/installation/) installed in the cluster
-- [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/installation/) installed in the cluster
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) installed and configured
 - [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html) installed and configured
@@ -32,7 +31,7 @@
 
 By following the instructions in this guide, you will successfully install the AI DIAL system with configured connection to the Vertex AI, OpenAI, Bedrock APIs.\
 Please note that this guide represents a very basic deployment scenario, and **should never be used in production**.\
-For authenticaConfiguring authentication provider, encrypted secrets, model usage limits, Ingress allowlisting and other security measures are **out of scope** of this guide.
+Configuring authentication provider, encrypted secrets, model usage limits, Ingress allowlisting and other security measures are **out of scope** of this guide.
 
 ## Install
 

--- a/charts/dial/examples/aws/complete/README.md
+++ b/charts/dial/examples/aws/complete/README.md
@@ -20,7 +20,6 @@
 - [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
 - [Amazon Cognito](https://docs.dialx.ai/tutorials/devops/auth-and-access-control/configure-idps/cognito)
 - [Amazon ElastiCache for Redis with user configured in IAM authentication mode](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth-iam.html)
-- [AWS Bedrock Regional availability by models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-region-compatibility.html)
 - [Google Vertex AI](https://cloud.google.com/vertex-ai/docs/start/introduction-unified-platform)
   - [Vertex AI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 - [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview)
@@ -76,6 +75,7 @@ For authenticaConfiguring authentication provider, encrypted secrets, model usag
     - Replace `%%GCP_PROJECT_ID%%` - with GCP Project id
     - Replace `%%GCP_SERVICE_ACCOUNT_AUDIENCE%%` with audience value from %%GCP_WORKLOAD_IDENTITY_CREDS%%
     - Replace `%%GCP_WORKLOAD_IDENTITY_CREDS%%` - with GCP Workload Identity
+    - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
       ```json
           {

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -42,25 +42,25 @@ core:
                   }
               ]
           },
-          "gemini-chat-latest": {
+          "gemini-3.5-flash": {
             "type": "chat",
             "displayName": "Google (Gemini)",
             "iconUrl": "/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-chat-latest/chat/completions"
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions"
           },
-          "anthropic-chat-latest": {
+          "anthropic.claude-opus-4-8": {
               "type": "chat",
-              "displayName": "Anthropic (Claude)",
+              "displayName": "Anthropic (Opus)",
               "iconUrl": "/anthropic.svg",
-              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic-chat-latest/chat/completions"
+              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic.claude-opus-4-8/chat/completions"
           }
         },
         "roles": {
           "chat": {
             "limits": {
               "gpt-chat-latest": {},
-              "gemini-chat-latest": {},
-              "anthropic-chat-latest": {}
+              "gemini-3.5-flash": {},
+              "anthropic.claude-opus-4-8": {}
             }
           }
         }

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -31,16 +31,16 @@ core:
     aidial.config.json: |
       {
         "models": {
-            "gpt-chat-latest": {
-              "type": "chat",
-              "displayName": "GPT Chat Latest",
-              "iconUrl": "gptchatlatest.svg",
-              "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-chat-latest/chat/completions",
-              "upstreams": [
-                  {
-                      "endpoint": "http://%%AZURE_DEPLOYMENT_HOST%%/openai/deployments/gpt-chat-latest/chat/completions"
-                  }
-              ]
+          "gpt-chat-latest": {
+            "type": "chat",
+            "displayName": "GPT Chat Latest",
+            "iconUrl": "gptchatlatest.svg",
+            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
+            "upstreams": [
+              {
+                  "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
+              }
+            ]
           },
           "gemini-3.5-flash": {
             "type": "chat",
@@ -49,10 +49,19 @@ core:
             "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions"
           },
           "anthropic.claude-opus-4-8": {
-              "type": "chat",
-              "displayName": "Anthropic (Opus)",
-              "iconUrl": "/anthropic.svg",
-              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
+            "type": "chat",
+            "displayName": "Anthropic Claude Opus 4.8",
+            "iconUrl": "/anthropic.svg",
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
+            "upstreams": [
+              {
+                  "endpoint": "%%AWS_BEDROCK_REGION%%",
+                  "extraData": {
+                      "region": "%%AWS_BEDROCK_REGION%%",
+                      "compatible_model_id": "anthropic.claude-opus-4-6-v1"
+                  }
+              }
+            ]
           }
         },
         "roles": {

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -38,8 +38,7 @@ core:
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
             "upstreams": [
               {
-                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses",
-                "key": "%%AZURE_MODEL_KEY%%"
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
               }
             ]
           },

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -5,6 +5,9 @@ core:
     # -- You can use a aidial.storage.identity/aidial.storage.credential in the environment variable instead.
     annotations:
       eks.amazonaws.com/role-arn: "%%AWS_CORE_ROLE_ARN%%"
+  podAnnotations:
+    # -- Annotation hack to restart core pod after each Helm chart upgrade
+    autorestart: '{{ dateInZone "2006-01-02 15:04:05Z" (now) "UTC" }}'
   configuration:
     encryption:
       secret: "%%CORE_ENCRYPT_SECRET%%"
@@ -209,7 +212,7 @@ openai:
     azure.workload.identity/use: "true"
 
   serviceAccount:
-    enabled: true
+    create: true
     name: dial-openai
     annotations:
       azure.workload.identity/client-id: "%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%"

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -52,7 +52,7 @@ core:
               "type": "chat",
               "displayName": "Anthropic (Opus)",
               "iconUrl": "/anthropic.svg",
-              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic.claude-opus-4-8/chat/completions"
+              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
           }
         },
         "roles": {

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -63,7 +63,6 @@ core:
             "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions",
             "upstreams": [
               {
-                "endpoint": "%%AWS_BEDROCK_REGION%%",
                 "extraData": {
                   "region": "%%AWS_BEDROCK_REGION%%"
                 }

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -99,7 +99,7 @@ core:
       alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=86400
       alb.ingress.kubernetes.io/load-balancer-attributes: routing.http2.enabled=true
       alb.ingress.kubernetes.io/listen-ports: '[{ "HTTP" : 80, "HTTPS" : 443 }]'
-      alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+      alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
       alb.ingress.kubernetes.io/certificate-arn: "%%AWS_CERTIFICATE_ARN%%"
       alb.ingress.kubernetes.io/ssl-redirect: "443"
     hosts:
@@ -140,7 +140,7 @@ chat:
       alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=86400
       alb.ingress.kubernetes.io/load-balancer-attributes: routing.http2.enabled=true
       alb.ingress.kubernetes.io/listen-ports: '[{ "HTTP" : 80, "HTTPS" : 443 }]'
-      alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+      alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
       alb.ingress.kubernetes.io/certificate-arn: "%%AWS_CERTIFICATE_ARN%%"
       alb.ingress.kubernetes.io/ssl-redirect: "443"
     hosts:

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -30,42 +30,41 @@ core:
     aidial.identityProviders.cognito.loggingSalt: "loggingSalt"
     aidial.config.json: |
       {
-          "models": {
-              "gpt-4": {
-                  "type": "chat",
-                  "displayName": "GPT-4",
-                  "iconUrl": "https://themes.%%DOMAIN%%//gpt4.svg",
-                  "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-4-0613/chat/completions",
-                  "upstreams": [
-                      {
-                          "endpoint": "http://%%AZURE_DEPLOYMENT_HOST%%/openai/deployments/gpt-4/chat/completions"
-                      }
-                  ]
-              },
-              "chat-bison": {
-                  "type": "chat",
-                  "displayName": "PaLM2",
-                  "iconUrl": "https://themes.%%DOMAIN%%/palm2.svg",
-                  "endpoint": "http://dial-vertex.%%NAMESPACE%%.svc.cluster.local/openai/deployments/chat-bison-32k@002/chat/completions"
-              },
-              "anthropic.claude-v1": {
-                  "type": "chat",
-                  "displayName": "Anthropic (Claude)",
-                  "iconUrl": "https://themes.%%DOMAIN%%/anthropic.svg",
-                  "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic.claude-instant-v1/chat/completions"
-              }
-          },
-          "roles": {
-              "default": {
-                  "limits": {
-                      "gpt-4": {},
-                      "chat-bison": {},
-                      "anthropic.claude-v1": {}
+        "models": {
+            "gpt-5-2025-08-07": {
+              "type": "chat",
+              "displayName": "GPT-5",
+              "iconUrl": "/gpt5.svg",
+              "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-5-2025-08-07/chat/completions",
+              "upstreams": [
+                  {
+                      "endpoint": "http://%%AZURE_DEPLOYMENT_HOST%%/openai/deployments/gpt-5-2025-08-07/chat/completions"
                   }
-              }
+              ]
+          },
+          "gemini-2.5-pro": {
+            "type": "chat",
+            "displayName": "Gemini 2.5 Pro",
+            "iconUrl": "/Gemini.svg",
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-2.5-pro/chat/completions"
+          },
+          "anthropic.claude-opus-4-6-v1": {
+              "type": "chat",
+              "displayName": "Anthropic (Claude)",
+              "iconUrl": "/anthropic.svg",
+              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/us.anthropic.claude-sonnet-4-6/chat/completions"
           }
+        },
+        "roles": {
+          "chat": {
+            "limits": {
+              "gpt-5-2025-08-07": {},
+              "gemini-2.5-pro": {},
+              "anthropic.claude-opus-4-6-v1": {}
+            }
+          }
+        }
       }
-
   extraVolumes:
     - name: config
       secret:
@@ -80,7 +79,7 @@ core:
       subPath: aidial.config.json
       readOnly: true
 
-  redis:
+  valkey:
     enabled: false
 
   ingress:

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -54,7 +54,7 @@ core:
                   "region": "global"
                 }
               }
-            ],
+            ]
           },
           "anthropic.claude-opus-4-8": {
             "type": "chat",

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -34,11 +34,11 @@ core:
           "gpt-chat-latest": {
             "type": "chat",
             "displayName": "GPT Chat Latest",
-            "iconUrl": "gptchatlatest.svg",
+            "iconUrl": "gpt4.svg",
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
             "upstreams": [
               {
-                  "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
               }
             ]
           },
@@ -55,11 +55,10 @@ core:
             "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
             "upstreams": [
               {
-                  "endpoint": "%%AWS_BEDROCK_REGION%%",
-                  "extraData": {
-                      "region": "%%AWS_BEDROCK_REGION%%",
-                      "compatible_model_id": "anthropic.claude-opus-4-6-v1"
-                  }
+                "endpoint": "%%AWS_BEDROCK_REGION%%",
+                "extraData": {
+                  "region": "%%AWS_BEDROCK_REGION%%"
+                }
               }
             ]
           }

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -60,13 +60,6 @@ core:
             "displayName": "Anthropic Claude Opus 4.8",
             "iconUrl": "/anthropic.svg",
             "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions",
-            "upstreams": [
-              {
-                "extraData": {
-                  "region": "%%AWS_BEDROCK_REGION%%"
-                }
-              }
-            ]
           }
         },
         "roles": {
@@ -176,7 +169,6 @@ bedrock:
 
   env:
     DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
-    AWS_DEFAULT_REGION: "%%AWS_BEDROCK_REGION%%"
 
   serviceAccount:
     create: true
@@ -189,7 +181,7 @@ vertexai:
 
   env:
     GOOGLE_APPLICATION_CREDENTIALS: "/etc/workload-identity/credential.json"
-    AWS_DEFAULT_REGION: "us-central1"
+    DEFAULT_REGION: "%%GCP_REGION%%"
     GCP_PROJECT_ID: "%%GCP_PROJECT_ID%%"
     DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
 

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -36,6 +36,16 @@ core:
             "displayName": "GPT Chat Latest",
             "iconUrl": "gpt4.svg",
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
+            "auth": {
+              "type": "bearer",
+              "apiKeyEnv": "%%AZURE_MODEL_KEY%%",
+              "header": "Authorization",
+              "prefix": "Bearer "
+            },
+            "provider": {
+              "name": "openai-compatible",
+              "requiresApiKey": true
+            },
             "upstreams": [
               {
                 "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
@@ -52,7 +62,7 @@ core:
             "type": "chat",
             "displayName": "Anthropic Claude Opus 4.8",
             "iconUrl": "/anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions",
             "upstreams": [
               {
                 "endpoint": "%%AWS_BEDROCK_REGION%%",

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -175,7 +175,7 @@ bedrock:
   enabled: true
 
   env:
-    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
     AWS_DEFAULT_REGION: "%%AWS_BEDROCK_REGION%%"
 
   serviceAccount:
@@ -191,7 +191,7 @@ vertexai:
     GOOGLE_APPLICATION_CREDENTIALS: "/etc/workload-identity/credential.json"
     AWS_DEFAULT_REGION: "us-central1"
     GCP_PROJECT_ID: "%%GCP_PROJECT_ID%%"
-    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
 
   extraDeploy:
     - apiVersion: v1
@@ -226,7 +226,7 @@ openai:
   enabled: true
 
   env:
-    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
 
   podLabels:
     azure.workload.identity/use: "true"

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -36,19 +36,10 @@ core:
             "displayName": "GPT Chat Latest",
             "iconUrl": "gpt4.svg",
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
-            "auth": {
-              "type": "bearer",
-              "apiKeyEnv": "%%AZURE_MODEL_KEY%%",
-              "header": "Authorization",
-              "prefix": "Bearer "
-            },
-            "provider": {
-              "name": "openai-compatible",
-              "requiresApiKey": true
-            },
             "upstreams": [
               {
-                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses",
+                "key": "%%AZURE_MODEL_KEY%%"
               }
             ]
           },
@@ -56,7 +47,14 @@ core:
             "type": "chat",
             "displayName": "Google (Gemini)",
             "iconUrl": "/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions"
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions",
+            "upstreams": [
+              {
+                "extraData": {
+                  "region": "global"
+                }
+              }
+            ],
           },
           "anthropic.claude-opus-4-8": {
             "type": "chat",

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -31,36 +31,36 @@ core:
     aidial.config.json: |
       {
         "models": {
-            "gpt-5-2025-08-07": {
+            "gpt-chat-latest": {
               "type": "chat",
-              "displayName": "GPT-5",
-              "iconUrl": "/gpt5.svg",
-              "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-5-2025-08-07/chat/completions",
+              "displayName": "GPT Chat Latest",
+              "iconUrl": "gptchatlatest.svg",
+              "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-chat-latest/chat/completions",
               "upstreams": [
                   {
-                      "endpoint": "http://%%AZURE_DEPLOYMENT_HOST%%/openai/deployments/gpt-5-2025-08-07/chat/completions"
+                      "endpoint": "http://%%AZURE_DEPLOYMENT_HOST%%/openai/deployments/gpt-chat-latest/chat/completions"
                   }
               ]
           },
-          "gemini-2.5-pro": {
+          "gemini-chat-latest": {
             "type": "chat",
-            "displayName": "Gemini 2.5 Pro",
+            "displayName": "Google (Gemini)",
             "iconUrl": "/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-2.5-pro/chat/completions"
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-chat-latest/chat/completions"
           },
-          "anthropic.claude-opus-4-6-v1": {
+          "anthropic-chat-latest": {
               "type": "chat",
               "displayName": "Anthropic (Claude)",
               "iconUrl": "/anthropic.svg",
-              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/us.anthropic.claude-sonnet-4-6/chat/completions"
+              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic-chat-latest/chat/completions"
           }
         },
         "roles": {
           "chat": {
             "limits": {
-              "gpt-5-2025-08-07": {},
-              "gemini-2.5-pro": {},
-              "anthropic.claude-opus-4-6-v1": {}
+              "gpt-chat-latest": {},
+              "gemini-chat-latest": {},
+              "anthropic-chat-latest": {}
             }
           }
         }

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -45,7 +45,7 @@ core:
           "gemini-3.5-flash": {
             "type": "chat",
             "displayName": "Google (Gemini)",
-            "iconUrl": "/Gemini.svg",
+            "iconUrl": "Gemini.svg",
             "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions",
             "upstreams": [
               {
@@ -58,8 +58,8 @@ core:
           "anthropic.claude-opus-4-8": {
             "type": "chat",
             "displayName": "Anthropic Claude Opus 4.8",
-            "iconUrl": "/anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions",
+            "iconUrl": "anthropic.svg",
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
           }
         },
         "roles": {
@@ -119,7 +119,7 @@ chat:
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
     # -- External or Internal URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
-    THEMES_CONFIG_HOST: "https://%%THEMES_CONFIG_HOST%%"
+    THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
     DEFAULT_MODEL: "anthropic.claude-opus-4-8"
 
   secrets:
@@ -148,21 +148,6 @@ chat:
 
 themes:
   enabled: true
-  ingress:
-    enabled: true
-    ingressClassName: alb
-    annotations:
-      alb.ingress.kubernetes.io/scheme: internet-facing
-      alb.ingress.kubernetes.io/target-type: ip
-      alb.ingress.kubernetes.io/healthcheck-path: /health
-      alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=86400
-      alb.ingress.kubernetes.io/load-balancer-attributes: routing.http2.enabled=true
-      alb.ingress.kubernetes.io/listen-ports: '[{ "HTTP" : 80, "HTTPS" : 443 }]'
-      alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
-      alb.ingress.kubernetes.io/certificate-arn: "%%AWS_CERTIFICATE_ARN%%"
-      alb.ingress.kubernetes.io/ssl-redirect: "443"
-    hosts:
-      - themes.%%DOMAIN%%
 
 bedrock:
   enabled: true

--- a/charts/dial/examples/aws/complete/values.yaml
+++ b/charts/dial/examples/aws/complete/values.yaml
@@ -124,9 +124,10 @@ chat:
     # -- List of DIAL chat features to enable;
     # ref: https://github.com/epam/ai-dial-chat/blob/development/libs/shared/src/types/features.ts
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
-    # -- External URL of DIAL themes;
+    # -- External or Internal URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
-    THEMES_CONFIG_HOST: "https://themes.%%DOMAIN%%"
+    THEMES_CONFIG_HOST: "https://%%THEMES_CONFIG_HOST%%"
+    DEFAULT_MODEL: "anthropic.claude-opus-4-8"
 
   secrets:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
@@ -175,6 +176,7 @@ bedrock:
 
   env:
     DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    AWS_DEFAULT_REGION: "%%AWS_BEDROCK_REGION%%"
 
   serviceAccount:
     create: true
@@ -187,7 +189,7 @@ vertexai:
 
   env:
     GOOGLE_APPLICATION_CREDENTIALS: "/etc/workload-identity/credential.json"
-    DEFAULT_REGION: "us-central1"
+    AWS_DEFAULT_REGION: "us-central1"
     GCP_PROJECT_ID: "%%GCP_PROJECT_ID%%"
     DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
 

--- a/charts/dial/examples/aws/simple/README.md
+++ b/charts/dial/examples/aws/simple/README.md
@@ -11,8 +11,9 @@
 
 - EKS 1.24+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
+- [Gateway API CRD](https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-a-gateway-controller) installed in the cluster
+- [Ingress-Traefik Controller](https://doc.traefik.io/traefik/setup/kubernetes/) installed in the cluster
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
-- [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/installation/) installed in the cluster
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) installed and configured
 - [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)

--- a/charts/dial/examples/aws/simple/README.md
+++ b/charts/dial/examples/aws/simple/README.md
@@ -16,7 +16,7 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) installed and configured
 - [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
-- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic-chat-latest` model deployed:
+- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic.claude-opus-4-8` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/aws/simple/README.md
+++ b/charts/dial/examples/aws/simple/README.md
@@ -11,8 +11,6 @@
 
 - EKS 1.24+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
-- [Gateway API CRD](https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-a-gateway-controller) installed in the cluster
-- [Ingress-Traefik Controller](https://doc.traefik.io/traefik/setup/kubernetes/) installed in the cluster
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) installed and configured

--- a/charts/dial/examples/aws/simple/README.md
+++ b/charts/dial/examples/aws/simple/README.md
@@ -66,7 +66,6 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AWS_CORE_S3_BUCKET_NAME%%` with S3 bucket name from [prerequisites](#prerequisites)
     - Replace `%%AWS_BEDROCK_ROLE_ARN%%` with bedrock AWS role ARN from [prerequisites](#prerequisites)
     - It's assumed you've configured **external-dns** and **aws-load-balancer-controller** beforehand, so replace `%%DOMAIN%%` with your domain name, e.g. `example.com`, and `%%AWS_CERTIFICATE_ARN%%` with your AWS ACM certificate ARN, e.g. `arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012`
-    - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
 1. Install `dial` helm chart in created namespace, applying custom values file:
 

--- a/charts/dial/examples/aws/simple/README.md
+++ b/charts/dial/examples/aws/simple/README.md
@@ -16,7 +16,6 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) installed and configured
 - [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
-- [Amazon Bedrock Regional availability by models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-region-compatibility.html)
 - [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `global.anthropic.claude-opus-4-8` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 
@@ -69,6 +68,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AWS_BEDROCK_ROLE_ARN%%` with bedrock AWS role ARN from [prerequisites](#prerequisites)
     - Replace `%%AWS_BEDROCK_REGION%%` with bedrock region from [prerequisites](#prerequisites)
     - It's assumed you've configured **external-dns** and **aws-load-balancer-controller** beforehand, so replace `%%DOMAIN%%` with your domain name, e.g. `example.com`, and `%%AWS_CERTIFICATE_ARN%%` with your AWS ACM certificate ARN, e.g. `arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012`
+    - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
 1. Install `dial` helm chart in created namespace, applying custom values file:
 

--- a/charts/dial/examples/aws/simple/README.md
+++ b/charts/dial/examples/aws/simple/README.md
@@ -12,6 +12,7 @@
 - EKS 1.24+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
+- [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/installation/) installed in the cluster
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) installed and configured
 - [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)

--- a/charts/dial/examples/aws/simple/README.md
+++ b/charts/dial/examples/aws/simple/README.md
@@ -16,7 +16,7 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) installed and configured
 - [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
-- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `us.anthropic.claude-sonnet-4-6` model deployed:
+- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic-chat-latest` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/aws/simple/README.md
+++ b/charts/dial/examples/aws/simple/README.md
@@ -16,7 +16,7 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) installed and configured
 - [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
-- [Amazonr Bedrock Regional availability by models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-region-compatibility.html)
+- [Amazon Bedrock Regional availability by models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-region-compatibility.html)
 - [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `global.anthropic.claude-opus-4-8` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 

--- a/charts/dial/examples/aws/simple/README.md
+++ b/charts/dial/examples/aws/simple/README.md
@@ -16,7 +16,7 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) installed and configured
 - [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
-- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic.claude-opus-4-8` model deployed:
+- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `global.anthropic.claude-opus-4-8` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/aws/simple/README.md
+++ b/charts/dial/examples/aws/simple/README.md
@@ -16,6 +16,7 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) installed and configured
 - [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
+- [Amazonr Bedrock Regional availability by models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-region-compatibility.html)
 - [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `global.anthropic.claude-opus-4-8` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 

--- a/charts/dial/examples/aws/simple/README.md
+++ b/charts/dial/examples/aws/simple/README.md
@@ -65,7 +65,6 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AWS_CORE_ROLE_ARN%%` with S3 AWS role ARN from [prerequisites](#prerequisites)
     - Replace `%%AWS_CORE_S3_BUCKET_NAME%%` with S3 bucket name from [prerequisites](#prerequisites)
     - Replace `%%AWS_BEDROCK_ROLE_ARN%%` with bedrock AWS role ARN from [prerequisites](#prerequisites)
-    - Replace `%%AWS_BEDROCK_REGION%%` with bedrock region from [prerequisites](#prerequisites)
     - It's assumed you've configured **external-dns** and **aws-load-balancer-controller** beforehand, so replace `%%DOMAIN%%` with your domain name, e.g. `example.com`, and `%%AWS_CERTIFICATE_ARN%%` with your AWS ACM certificate ARN, e.g. `arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012`
     - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 

--- a/charts/dial/examples/aws/simple/README.md
+++ b/charts/dial/examples/aws/simple/README.md
@@ -16,7 +16,7 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) installed and configured
 - [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
-- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic.claude-v1` model deployed:
+- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `us.anthropic.claude-sonnet-4-6` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -29,7 +29,7 @@ core:
             "type": "chat",
             "displayName": "Anthropic (Opus)",
             "iconUrl": "anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic.claude-opus-4-8/chat/completions"
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
           }
         },
         "keys": {

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -25,11 +25,11 @@ core:
     aidial.config.json: |
       {
         "models": {
-          "anthropic.claude-v1": {
+          "anthropic.claude-opus-4-6-v1": {
             "type": "chat",
             "displayName": "Anthropic (Claude)",
             "iconUrl": "anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic.claude-instant-v1/chat/completions"
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/us.anthropic.claude-sonnet-4-6/chat/completions"
           }
         },
         "keys": {
@@ -41,7 +41,7 @@ core:
         "roles": {
           "chat": {
             "limits": {
-              "anthropic.claude-v1": {}
+              "anthropic.claude-opus-4-6-v1": {}
             }
           }
         }
@@ -58,9 +58,14 @@ core:
       mountPath: "/mnt/secrets-store/aidial.config.json"
       subPath: aidial.config.json
       readOnly: true
-  redis:
+
+  valkey:
     enabled: true
-    password: "%%REDIS_PASSWORD%%"
+    auth:
+      enabled: true
+      aclUsers:
+        default:
+          password: "%%REDIS_PASSWORD%%"
   ingress:
     enabled: false
 

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -105,27 +105,12 @@ chat:
     DIAL_API_KEY: "%%DIAL_API_KEY%%"
 
   ingress:
-    enabled: true
-    ingressClassName: traefik
-    annotations:
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%" # To issue ssl certificate
-    hosts:
-      - chat.%%DOMAIN%%
-    tls:
-      - secretName: "chat-tls"
-        hosts:
-          - chat.%%DOMAIN%%
+    enabled: false
 
 themes:
   enabled: true
-  httpRoute:
-    enabled: true
-    parentRefs:
-      - name: traefik
-        namespace: traefik
-        sectionName: websecure
-    hostnames:
-      - themes.%%DOMAIN%%
+  ingress:
+    enabled: false
 
 bedrock:
   enabled: true

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -29,7 +29,7 @@ core:
             "type": "chat",
             "displayName": "Anthropic Claude Opus 4.8",
             "iconUrl": "/anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions",
             "upstreams": [
               {
                 "endpoint": "us-east-1",

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -25,11 +25,11 @@ core:
     aidial.config.json: |
       {
         "models": {
-          "anthropic-chat-latest": {
+          "anthropic.claude-opus-4-8": {
             "type": "chat",
-            "displayName": "Anthropic (Claude)",
+            "displayName": "Anthropic (Opus)",
             "iconUrl": "anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic-chat-latest/chat/completions"
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic.claude-opus-4-8/chat/completions"
           }
         },
         "keys": {
@@ -41,7 +41,7 @@ core:
         "roles": {
           "chat": {
             "limits": {
-              "anthropic-chat-latest": {}
+              "anthropic.claude-opus-4-8": {}
             }
           }
         }

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -25,11 +25,11 @@ core:
     aidial.config.json: |
       {
         "models": {
-          "anthropic.claude-opus-4-6-v1": {
+          "anthropic-chat-latest": {
             "type": "chat",
             "displayName": "Anthropic (Claude)",
             "iconUrl": "anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/us.anthropic.claude-sonnet-4-6/chat/completions"
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic-chat-latest/chat/completions"
           }
         },
         "keys": {
@@ -41,7 +41,7 @@ core:
         "roles": {
           "chat": {
             "limits": {
-              "anthropic.claude-opus-4-6-v1": {}
+              "anthropic-chat-latest": {}
             }
           }
         }

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -121,8 +121,14 @@ chat:
 
 themes:
   enabled: true
-  ingress:
-    enabled: false
+  httpRoute:
+    enabled: true
+    parentRefs:
+      - name: traefik
+        namespace: traefik
+        sectionName: websecure
+    hostnames:
+      - themes.%%DOMAIN%%
 
 bedrock:
   enabled: true

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -28,7 +28,7 @@ core:
           "anthropic.claude-opus-4-8": {
             "type": "chat",
             "displayName": "Anthropic Claude Opus 4.8",
-            "iconUrl": "/anthropic.svg",
+            "iconUrl": "anthropic.svg",
             "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
           }
         },
@@ -98,7 +98,7 @@ chat:
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
     # -- External or Internal URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
-    THEMES_CONFIG_HOST: "https://%%THEMES_CONFIG_HOST%%"
+    THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
     DEFAULT_MODEL: "anthropic.claude-opus-4-8"
   secrets:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
@@ -110,8 +110,6 @@ chat:
 
 themes:
   enabled: true
-  ingress:
-    enabled: false
 
 bedrock:
   enabled: true

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -134,5 +134,5 @@ bedrock:
       eks.amazonaws.com/role-arn: "%%AWS_BEDROCK_ROLE_ARN%%"
 
   env:
-    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
     AWS_DEFAULT_REGION: "%%AWS_BEDROCK_REGION%%"

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -65,7 +65,7 @@ core:
       enabled: true
       aclUsers:
         default:
-          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
+          permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
 
   ingress:

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -103,21 +103,18 @@ chat:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
     # -- API key defined in core configuration
     DIAL_API_KEY: "%%DIAL_API_KEY%%"
+
   ingress:
     enabled: true
-    ingressClassName: alb
+    ingressClassName: traefik
     annotations:
-      alb.ingress.kubernetes.io/scheme: internet-facing
-      alb.ingress.kubernetes.io/target-type: ip
-      alb.ingress.kubernetes.io/healthcheck-path: /api/health
-      alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=86400
-      alb.ingress.kubernetes.io/load-balancer-attributes: routing.http2.enabled=true
-      alb.ingress.kubernetes.io/listen-ports: '[{ "HTTP" : 80, "HTTPS" : 443 }]'
-      alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
-      alb.ingress.kubernetes.io/certificate-arn: "%%AWS_CERTIFICATE_ARN%%"
-      alb.ingress.kubernetes.io/ssl-redirect: "443"
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%" # To issue ssl certificate
     hosts:
       - chat.%%DOMAIN%%
+    tls:
+      - secretName: "chat-tls"
+        hosts:
+          - chat.%%DOMAIN%%
 
 themes:
   enabled: true

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -32,9 +32,8 @@ core:
             "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions",
             "upstreams": [
               {
-                "endpoint": "us-east-1",
                 "extraData": {
-                  "region": "us-east-1"
+                  "region": "%%AWS_BEDROCK_REGION%%"
                 }
               }
             ]

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -123,4 +123,3 @@ bedrock:
 
   env:
     DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
-    AWS_DEFAULT_REGION: "%%AWS_BEDROCK_REGION%%"

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -65,6 +65,7 @@ core:
       enabled: true
       aclUsers:
         default:
+          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
 
   ingress:

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -29,14 +29,7 @@ core:
             "type": "chat",
             "displayName": "Anthropic Claude Opus 4.8",
             "iconUrl": "/anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions",
-            "upstreams": [
-              {
-                "extraData": {
-                  "region": "%%AWS_BEDROCK_REGION%%"
-                }
-              }
-            ]
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
           }
         },
         "keys": {
@@ -72,10 +65,23 @@ core:
       enabled: true
       aclUsers:
         default:
-          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
+
   ingress:
-    enabled: false
+    enabled: true
+    ingressClassName: alb
+    annotations:
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/target-type: ip
+      alb.ingress.kubernetes.io/healthcheck-path: /health
+      alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=86400
+      alb.ingress.kubernetes.io/load-balancer-attributes: routing.http2.enabled=true
+      alb.ingress.kubernetes.io/listen-ports: '[{ "HTTP" : 80, "HTTPS" : 443 }]'
+      alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+      alb.ingress.kubernetes.io/certificate-arn: "%%AWS_CERTIFICATE_ARN%%"
+      alb.ingress.kubernetes.io/ssl-redirect: "443"
+    hosts:
+      - dial.%%DOMAIN%%
 
 chat:
   enabled: true
@@ -89,9 +95,10 @@ chat:
     # -- List of DIAL chat features to enable;
     # ref: https://github.com/epam/ai-dial-chat/blob/development/libs/shared/src/types/features.ts
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
-    # -- External URL of DIAL themes;
+    # -- External or Internal URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
-    THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
+    THEMES_CONFIG_HOST: "https://%%THEMES_CONFIG_HOST%%"
+    DEFAULT_MODEL: "anthropic.claude-opus-4-8"
   secrets:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
     # -- API key defined in core configuration
@@ -127,5 +134,5 @@ bedrock:
       eks.amazonaws.com/role-arn: "%%AWS_BEDROCK_ROLE_ARN%%"
 
   env:
-    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
-    DEFAULT_REGION: "%%AWS_BEDROCK_REGION%%"
+    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    AWS_DEFAULT_REGION: "%%AWS_BEDROCK_REGION%%"

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -27,9 +27,18 @@ core:
         "models": {
           "anthropic.claude-opus-4-8": {
             "type": "chat",
-            "displayName": "Anthropic (Opus)",
-            "iconUrl": "anthropic.svg",
+            "displayName": "Anthropic Claude Opus 4.8",
+            "iconUrl": "/anthropic.svg",
             "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
+            "upstreams": [
+              {
+                  "endpoint": "us-east-1",
+                  "extraData": {
+                      "region": "us-east-1",
+                      "compatible_model_id": "anthropic.claude-opus-4-6-v1"
+                  }
+              }
+            ]
           }
         },
         "keys": {

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -65,6 +65,7 @@ core:
       enabled: true
       aclUsers:
         default:
+          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
   ingress:
     enabled: false

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -32,11 +32,10 @@ core:
             "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
             "upstreams": [
               {
-                  "endpoint": "us-east-1",
-                  "extraData": {
-                      "region": "us-east-1",
-                      "compatible_model_id": "anthropic.claude-opus-4-6-v1"
-                  }
+                "endpoint": "us-east-1",
+                "extraData": {
+                  "region": "us-east-1"
+                }
               }
             ]
           }

--- a/charts/dial/examples/aws/simple/values.yaml
+++ b/charts/dial/examples/aws/simple/values.yaml
@@ -78,7 +78,7 @@ core:
       alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=86400
       alb.ingress.kubernetes.io/load-balancer-attributes: routing.http2.enabled=true
       alb.ingress.kubernetes.io/listen-ports: '[{ "HTTP" : 80, "HTTPS" : 443 }]'
-      alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+      alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
       alb.ingress.kubernetes.io/certificate-arn: "%%AWS_CERTIFICATE_ARN%%"
       alb.ingress.kubernetes.io/ssl-redirect: "443"
     hosts:
@@ -106,7 +106,20 @@ chat:
     DIAL_API_KEY: "%%DIAL_API_KEY%%"
 
   ingress:
-    enabled: false
+    enabled: true
+    ingressClassName: alb
+    annotations:
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/target-type: ip
+      alb.ingress.kubernetes.io/healthcheck-path: /api/health
+      alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=86400
+      alb.ingress.kubernetes.io/load-balancer-attributes: routing.http2.enabled=true
+      alb.ingress.kubernetes.io/listen-ports: '[{ "HTTP" : 80, "HTTPS" : 443 }]'
+      alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
+      alb.ingress.kubernetes.io/certificate-arn: "%%AWS_CERTIFICATE_ARN%%"
+      alb.ingress.kubernetes.io/ssl-redirect: "443"
+    hosts:
+      - chat.%%DOMAIN%%
 
 themes:
   enabled: true

--- a/charts/dial/examples/azure/complete/README.md
+++ b/charts/dial/examples/azure/complete/README.md
@@ -25,9 +25,9 @@
   - [Use Microsoft Entra for cache authentication](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-azure-active-directory-for-authentication)
 - [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview)
   - [OpenAI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/openai-model-deployment)
-- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-chat-latest` model deployed:
+- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-3.5-flash` model deployed:
   - [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
-- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic-chat-latest` model deployed:
+- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic.claude-opus-4-8` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/azure/complete/README.md
+++ b/charts/dial/examples/azure/complete/README.md
@@ -25,9 +25,9 @@
   - [Use Microsoft Entra for cache authentication](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-azure-active-directory-for-authentication)
 - [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview)
   - [OpenAI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/openai-model-deployment)
-- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-1.5-pro` model deployed:
+- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-chat-latest` model deployed:
   - [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
-- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic.claude-v1` model deployed:
+- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic-chat-latest` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/azure/complete/README.md
+++ b/charts/dial/examples/azure/complete/README.md
@@ -75,7 +75,8 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%` with appropriate workload identity from [prerequisites](#prerequisites)
-    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with appropriate endpoint from [prerequisites](#prerequisites)
+    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `https://not-a-real-endpoint.openai.azure.com/openai/v1/responses`
+    - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - Replace `%%AZURE_CLIENT_ID%%` with a unique identifier for the client application registered in Azure Active Directory (AD). It is used to authenticate the client application when accessing Azure AD resources.
     - Replace `%%AZURE_TENANT_ID%%` with a Tenant ID refers to a globally unique identifier (GUID) that represents a specific Azure AD tenant. It is used to identify and authenticate the Azure AD tenant that the client application belongs to.
     - Replace `%%AZURE_CLIENT_SECRET%%` with a client secret or application secret, this parameter is a confidential string that authenticates and authorizes the client application to access Azure AD resources. It serves as a password for the client application.

--- a/charts/dial/examples/azure/complete/README.md
+++ b/charts/dial/examples/azure/complete/README.md
@@ -16,6 +16,7 @@
 - [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html) installed and configured
 - [GCP Workload Identity Federation with Kubernetes](https://cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes#eks) configured
 - [AWS IAM credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/getting-started-workloads.html)  installed and configured
+- [AWS Bedrock Regional availability by models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-region-compatibility.html)
 - [Static IP address](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-addresses) reserved for Chat
 - [DNS records](https://learn.microsoft.com/en-us/azure/dns/public-dns-overview) configured for Chat
 - [Azure-managed SSL certificates](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate) issued for Chat
@@ -91,6 +92,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%` with appropriate workload identity from [prerequisites](#prerequisites)
     - Replace `%%GCP_SERVICE_ACCOUNT_AUDIENCE%%` with audience value from %%GCP_WORKLOAD_IDENTITY_CREDS%%
     - Replace `%%GCP_WORKLOAD_IDENTITY_CREDS%%` - with GCP Workload Identity
+    - Replace `%%AWS_BEDROCK_REGION%%` with bedrock region from [prerequisites](#prerequisites)
 
     ```json
         {

--- a/charts/dial/examples/azure/complete/README.md
+++ b/charts/dial/examples/azure/complete/README.md
@@ -16,7 +16,6 @@
 - [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html) installed and configured
 - [GCP Workload Identity Federation with Kubernetes](https://cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes#eks) configured
 - [AWS IAM credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/getting-started-workloads.html)  installed and configured
-- [AWS Bedrock Regional availability by models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-region-compatibility.html)
 - [Static IP address](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-addresses) reserved for Chat
 - [DNS records](https://learn.microsoft.com/en-us/azure/dns/public-dns-overview) configured for Chat
 - [Azure-managed SSL certificates](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate) issued for Chat
@@ -93,6 +92,8 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%GCP_SERVICE_ACCOUNT_AUDIENCE%%` with audience value from %%GCP_WORKLOAD_IDENTITY_CREDS%%
     - Replace `%%GCP_WORKLOAD_IDENTITY_CREDS%%` - with GCP Workload Identity
     - Replace `%%AWS_BEDROCK_REGION%%` with bedrock region from [prerequisites](#prerequisites)
+    - It's assumed you've configured **external-dns** and **cert-manager** beforehand, so replace `%%CLUSTER_ISSUER%%` with your cluster issuer name, e.g. `letsencrypt-production`
+    - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
     ```json
         {

--- a/charts/dial/examples/azure/complete/README.md
+++ b/charts/dial/examples/azure/complete/README.md
@@ -27,7 +27,7 @@
   - [OpenAI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/openai-model-deployment)
 - [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-3.5-flash` model deployed:
   - [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
-- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic.claude-opus-4-8` model deployed:
+- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `global.anthropic.claude-opus-4-8` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/azure/complete/README.md
+++ b/charts/dial/examples/azure/complete/README.md
@@ -81,10 +81,8 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AZURE_CLIENT_SECRET%%` with a client secret or application secret, this parameter is a confidential string that authenticates and authorizes the client application to access Azure AD resources. It serves as a password for the client application.
     - Replace `%%AZURE_CORE_BLOB_STORAGE_NAME%%` with Azure Blob storage name from [prerequisites](#prerequisites)
     - Replace `%%AZURE_CORE_BLOB_STORAGE_ENDPOINT%%` with Azure Blob storage endpoint from [prerequisites](#prerequisites)
-    - Replace `%%AZURE_CACHE_REDIS_ADDRESS%%` with Azure Cache for Redis endpoint, e.g. `[\"rediss://10.0.0.2:6380\"]`
-    - Replace `%%AZURE_CACHE_REDIS_PASSWORD%%` with Azure Cache for Redis password
+    - Replace `%%AZURE_CACHE_REDIS_ADDRESS%%` with Azure Cache for Redis endpoint, e.g. `rediss://10.0.0.2:6380`
     - Replace `%%GCP_REGION%%` with GCP Region e.g. `us-east1`
-    - Replace `%%AWS_REGION%%` with GCP Region e.g. `us-east-1`
     - Replace `%%GCP_PROJECT_ID%%` with GCP Project Id e.g. `dial-191923`
     - Replace `%%GCP_SERVICE_ACCOUNT_ID%%` with GCP service account id [link](https://cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes)
     - Replace `%%AWS_BEDROCK_ROLE_ARN%%` with bedrock AWS role ARN from [prerequisites](#prerequisites)

--- a/charts/dial/examples/azure/complete/README.md
+++ b/charts/dial/examples/azure/complete/README.md
@@ -75,7 +75,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%` with appropriate workload identity from [prerequisites](#prerequisites)
-    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `https://not-a-real-endpoint.openai.azure.com/openai/v1/responses`
+    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
     - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - Replace `%%AZURE_CLIENT_ID%%` with a unique identifier for the client application registered in Azure Active Directory (AD). It is used to authenticate the client application when accessing Azure AD resources.
     - Replace `%%AZURE_TENANT_ID%%` with a Tenant ID refers to a globally unique identifier (GUID) that represents a specific Azure AD tenant. It is used to identify and authenticate the Azure AD tenant that the client application belongs to.

--- a/charts/dial/examples/azure/complete/README.md
+++ b/charts/dial/examples/azure/complete/README.md
@@ -92,7 +92,6 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%GCP_SERVICE_ACCOUNT_AUDIENCE%%` with audience value from %%GCP_WORKLOAD_IDENTITY_CREDS%%
     - Replace `%%GCP_WORKLOAD_IDENTITY_CREDS%%` - with GCP Workload Identity
     - It's assumed you've configured **external-dns** and **cert-manager** beforehand, so replace `%%CLUSTER_ISSUER%%` with your cluster issuer name, e.g. `letsencrypt-production`
-    - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
     ```json
         {

--- a/charts/dial/examples/azure/complete/README.md
+++ b/charts/dial/examples/azure/complete/README.md
@@ -76,7 +76,6 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%` with appropriate workload identity from [prerequisites](#prerequisites)
     - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
-    - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - Replace `%%AZURE_CLIENT_ID%%` with a unique identifier for the client application registered in Azure Active Directory (AD). It is used to authenticate the client application when accessing Azure AD resources.
     - Replace `%%AZURE_TENANT_ID%%` with a Tenant ID refers to a globally unique identifier (GUID) that represents a specific Azure AD tenant. It is used to identify and authenticate the Azure AD tenant that the client application belongs to.
     - Replace `%%AZURE_CLIENT_SECRET%%` with a client secret or application secret, this parameter is a confidential string that authenticates and authorizes the client application to access Azure AD resources. It serves as a password for the client application.

--- a/charts/dial/examples/azure/complete/README.md
+++ b/charts/dial/examples/azure/complete/README.md
@@ -15,7 +15,8 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html) installed and configured
 - [GCP Workload Identity Federation with Kubernetes](https://cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes#eks) configured
-- [AWS IAM credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/getting-started-workloads.html)  installed and configured
+- [AWS IAM role for Bedrock access](https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.html) configured
+- [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook) installed in the cluster with the `--aws-default-region` flag set (required to inject `AWS_DEFAULT_REGION` into the Bedrock pod)
 - [Static IP address](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-addresses) reserved for Chat
 - [DNS records](https://learn.microsoft.com/en-us/azure/dns/public-dns-overview) configured for Chat
 - [Azure-managed SSL certificates](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-app-service-certificate) issued for Chat
@@ -86,12 +87,10 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AWS_REGION%%` with GCP Region e.g. `us-east-1`
     - Replace `%%GCP_PROJECT_ID%%` with GCP Project Id e.g. `dial-191923`
     - Replace `%%GCP_SERVICE_ACCOUNT_ID%%` with GCP service account id [link](https://cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes)
-    - Replace `%%AWS_ACCESS_KEY%%` with AWS access key from [prerequisites](#prerequisites)
-    - Replace `%%AWS_SECRET_KEY%%` with AWS secret key from [prerequisites](#prerequisites)
+    - Replace `%%AWS_BEDROCK_ROLE_ARN%%` with bedrock AWS role ARN from [prerequisites](#prerequisites)
     - Replace `%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%` with appropriate workload identity from [prerequisites](#prerequisites)
     - Replace `%%GCP_SERVICE_ACCOUNT_AUDIENCE%%` with audience value from %%GCP_WORKLOAD_IDENTITY_CREDS%%
     - Replace `%%GCP_WORKLOAD_IDENTITY_CREDS%%` - with GCP Workload Identity
-    - Replace `%%AWS_BEDROCK_REGION%%` with bedrock region from [prerequisites](#prerequisites)
     - It's assumed you've configured **external-dns** and **cert-manager** beforehand, so replace `%%CLUSTER_ISSUER%%` with your cluster issuer name, e.g. `letsencrypt-production`
     - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -33,38 +33,36 @@ core:
     aidial.config.json: |
       {
         "models": {
-          "gpt-35-turbo-0301": {
+            "gpt-5-2025-08-07": {
               "type": "chat",
-              "displayName": "GPT-3.5 Turbo",
-              "displayVersion": "0301",
-              "tokenizerModel": "gpt-3.5-turbo-0301",
-              "iconUrl": "gpt3.svg",
-              "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-35-turbo-0301/chat/completions",
+              "displayName": "GPT-5",
+              "iconUrl": "/gpt5.svg",
+              "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-5-2025-08-07/chat/completions",
               "upstreams": [
-                  {
-                      "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%.azure.com/openai/deployments/gpt-35-turbo-0301/chat/completions"
-                  }
+                {
+                  "endpoint": "http://%%AZURE_DEPLOYMENT_HOST%%/openai/deployments/gpt-5-2025-08-07/chat/completions"
+                }
               ]
           },
-           "gemini-1.5-pro-preview-0409": {
+          "gemini-2.5-pro": {
             "type": "chat",
-            "displayName": "Gemini 1.5 Pro",
-            "iconUrl": "Gemini-Pro-Vision.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-1.5-pro-preview-0409/chat/completions"
+            "displayName": "Gemini 2.5 Pro",
+            "iconUrl": "/Gemini.svg",
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-2.5-pro/chat/completions"
           },
-          "anthropic.claude-v2:1": {
+          "anthropic.claude-opus-4-6-v1": {
               "type": "chat",
               "displayName": "Anthropic (Claude)",
-              "iconUrl": "anthropic.svg",
-              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic.claude-v2:1/chat/completions"
+              "iconUrl": "/anthropic.svg",
+              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/us.anthropic.claude-sonnet-4-6/chat/completions"
           }
         },
         "roles": {
           "chat": {
             "limits": {
-              "gpt-4": {},
-              "gemini-1.5-pro-preview-0409": {},
-              "anthropic.claude-v2:1": {}
+              "gpt-5-2025-08-07": {},
+              "gemini-2.5-pro": {},
+              "anthropic.claude-opus-4-6-v1": {}
             }
           }
         }
@@ -81,7 +79,7 @@ core:
       mountPath: "/mnt/secrets-store/aidial.config.json"
       subPath: aidial.config.json
       readOnly: true
-  redis:
+  valkey:
     enabled: false
 
 chat:

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -36,7 +36,7 @@ core:
           "gpt-chat-latest": {
             "type": "chat",
             "displayName": "GPT Chat Latest",
-            "iconUrl": "gptchatlatest.svg",
+            "iconUrl": "gpt4.svg",
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
             "upstreams": [
               {
@@ -57,11 +57,10 @@ core:
             "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
             "upstreams": [
               {
-                  "endpoint": "%%AWS_BEDROCK_REGION%%",
-                  "extraData": {
-                      "region": "%%AWS_BEDROCK_REGION%%",
-                      "compatible_model_id": "anthropic.claude-opus-4-6-v1"
-                  }
+                "endpoint": "%%AWS_BEDROCK_REGION%%",
+                "extraData": {
+                  "region": "%%AWS_BEDROCK_REGION%%"
+                }
               }
             ]
           }

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -38,19 +38,10 @@ core:
             "displayName": "GPT Chat Latest",
             "iconUrl": "gpt4.svg",
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
-            "auth": {
-              "type": "bearer",
-              "apiKeyEnv": "%%AZURE_MODEL_KEY%%",
-              "header": "Authorization",
-              "prefix": "Bearer "
-            },
-            "provider": {
-              "name": "openai-compatible",
-              "requiresApiKey": true
-            },
             "upstreams": [
               {
-                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses",
+                "key": "%%AZURE_MODEL_KEY%%"
               }
             ]
           },
@@ -58,7 +49,14 @@ core:
             "type": "chat",
             "displayName": "Google (Gemini)",
             "iconUrl": "/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions"
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions",
+            "upstreams": [
+              {
+                "extraData": {
+                  "region": "global"
+                }
+              }
+            ],
           },
           "anthropic.claude-opus-4-8": {
             "type": "chat",

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -44,25 +44,25 @@ core:
                 }
               ]
           },
-          "gemini-chat-latest": {
+          "gemini-3.5-flash": {
             "type": "chat",
             "displayName": "Google (Gemini)",
             "iconUrl": "/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-chat-latest/chat/completions"
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions"
           },
-          "anthropic-chat-latest": {
+          "anthropic.claude-opus-4-8": {
               "type": "chat",
-              "displayName": "Anthropic (Claude)",
+              "displayName": "Anthropic (Opus)",
               "iconUrl": "/anthropic.svg",
-              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic-chat-latest/chat/completions"
+              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic.claude-opus-4-8/chat/completions"
           }
         },
         "roles": {
           "chat": {
             "limits": {
               "gpt-chat-latest": {},
-              "gemini-chat-latest": {},
-              "anthropic-chat-latest": {}
+              "gemini-3.5-flash": {},
+              "anthropic.claude-opus-4-8": {}
             }
           }
         }

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -65,7 +65,6 @@ core:
             "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions",
             "upstreams": [
               {
-                "endpoint": "%%AWS_BEDROCK_REGION%%",
                 "extraData": {
                   "region": "%%AWS_BEDROCK_REGION%%"
                 }

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -48,7 +48,7 @@ core:
           "gemini-3.5-flash": {
             "type": "chat",
             "displayName": "Google (Gemini)",
-            "iconUrl": "/Gemini.svg",
+            "iconUrl": "Gemini.svg",
             "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions",
             "upstreams": [
               {
@@ -61,7 +61,7 @@ core:
           "anthropic.claude-opus-4-8": {
             "type": "chat",
             "displayName": "Anthropic Claude Opus 4.8",
-            "iconUrl": "/anthropic.svg",
+            "iconUrl": "anthropic.svg",
             "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
           }
         },
@@ -116,7 +116,7 @@ chat:
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
     # -- External or Internal URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
-    THEMES_CONFIG_HOST: "https://%%THEMES_CONFIG_HOST%%"
+    THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
     DEFAULT_MODEL: "gpt-chat-latest"
   secrets:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
@@ -141,8 +141,6 @@ chat:
 
 themes:
   enabled: true
-  ingress:
-    enabled: false
 
 vertexai:
   enabled: true

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -56,7 +56,7 @@ core:
                   "region": "global"
                 }
               }
-            ],
+            ]
           },
           "anthropic.claude-opus-4-8": {
             "type": "chat",

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -40,8 +40,7 @@ core:
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
             "upstreams": [
               {
-                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses",
-                "key": "%%AZURE_MODEL_KEY%%"
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
               }
             ]
           },

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -154,7 +154,7 @@ vertexai:
 
   env:
     GOOGLE_APPLICATION_CREDENTIALS: "/etc/workload-identity/credential-configuration.json"
-    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
     GCP_PROJECT_ID: "%%GCP_PROJECT_ID%%"
     DEFAULT_REGION: "%%GCP_REGION%%"
 
@@ -192,7 +192,7 @@ bedrock:
 
   env:
     AWS_DEFAULT_REGION: "%%AWS_REGION%%"
-    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
     AWS_ACCESS_KEY_ID: "%%AWS_ACCESS_KEY%%"
     AWS_SECRET_ACCESS_KEY: "%%AWS_SECRET_KEY%%"
 

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -20,7 +20,6 @@ core:
     aidial.storage.prefix: "core"
     aidial.storage.overrides: '{"jclouds.oauth.credential-type": "bearerTokenCredentials", "jclouds.azureblob.auth" : "azureAd"}'
     aidial.identityProviders.azure.loggingKey: "sub"
-    aidial.identityProviders.azure.loggingSalt: "loggingSalt"
     aidial.identityProviders.azure.jwksUrl: "https://login.microsoftonline.com/%%AZURE_TENANT_ID%%/discovery/v2.0/keys"
     aidial.identityProviders.azure.rolePath: "groups"
     aidial.identityProviders.azure.issuerPattern: '^https:\/\/sts\.windows\.net.+$'
@@ -31,6 +30,7 @@ core:
     azure.workload.identity/use: "true"
 
   secrets:
+    aidial.identityProviders.azure.loggingSalt: "loggingSalt"
     aidial.config.json: |
       {
         "models": {
@@ -151,7 +151,7 @@ vertexai:
       iam.gke.io/gcp-service-account: "%%GCP_SERVICE_ACCOUNT_ID%%"
 
   env:
-    GOOGLE_APPLICATION_CREDENTIALS: "/etc/workload-identity/credential-configuration.json"
+    GOOGLE_APPLICATION_CREDENTIALS: "/etc/workload-identity/credential.json"
     DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
     GCP_PROJECT_ID: "%%GCP_PROJECT_ID%%"
     DEFAULT_REGION: "%%GCP_REGION%%"
@@ -209,6 +209,6 @@ openai:
     azure.workload.identity/use: "true"
 
   serviceAccount:
-    enabled: true
+    create: true
     annotations:
       azure.workload.identity/client-id: "%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%"

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -33,16 +33,16 @@ core:
     aidial.config.json: |
       {
         "models": {
-            "gpt-chat-latest": {
-              "type": "chat",
-              "displayName": "GPT Chat Latest",
-              "iconUrl": "gptchatlatest.svg",
-              "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-chat-latest/chat/completions",
-              "upstreams": [
-                {
-                  "endpoint": "http://%%AZURE_DEPLOYMENT_HOST%%/openai/deployments/gpt-chat-latest/chat/completions"
-                }
-              ]
+          "gpt-chat-latest": {
+            "type": "chat",
+            "displayName": "GPT Chat Latest",
+            "iconUrl": "gptchatlatest.svg",
+            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
+            "upstreams": [
+              {
+                  "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
+              }
+            ]
           },
           "gemini-3.5-flash": {
             "type": "chat",
@@ -51,10 +51,19 @@ core:
             "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions"
           },
           "anthropic.claude-opus-4-8": {
-              "type": "chat",
-              "displayName": "Anthropic (Opus)",
-              "iconUrl": "/anthropic.svg",
-              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
+            "type": "chat",
+            "displayName": "Anthropic Claude Opus 4.8",
+            "iconUrl": "/anthropic.svg",
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
+            "upstreams": [
+              {
+                  "endpoint": "%%AWS_BEDROCK_REGION%%",
+                  "extraData": {
+                      "region": "%%AWS_BEDROCK_REGION%%",
+                      "compatible_model_id": "anthropic.claude-opus-4-6-v1"
+                  }
+              }
+            ]
           }
         },
         "roles": {

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -191,13 +191,15 @@ bedrock:
   enabled: true
 
   env:
-    AWS_DEFAULT_REGION: "%%AWS_REGION%%"
     DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
-    AWS_ACCESS_KEY_ID: "%%AWS_ACCESS_KEY%%"
-    AWS_SECRET_ACCESS_KEY: "%%AWS_SECRET_KEY%%"
+
+  podLabels:
+    eks.amazonaws.com/pod-identity-webhook: "true"
 
   serviceAccount:
     create: true
+    annotations:
+      eks.amazonaws.com/role-arn: "%%AWS_BEDROCK_ROLE_ARN%%"
 
 openai:
   enabled: true

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -38,9 +38,19 @@ core:
             "displayName": "GPT Chat Latest",
             "iconUrl": "gpt4.svg",
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
+            "auth": {
+              "type": "bearer",
+              "apiKeyEnv": "%%AZURE_MODEL_KEY%%",
+              "header": "Authorization",
+              "prefix": "Bearer "
+            },
+            "provider": {
+              "name": "openai-compatible",
+              "requiresApiKey": true
+            },
             "upstreams": [
               {
-                  "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
               }
             ]
           },
@@ -54,7 +64,7 @@ core:
             "type": "chat",
             "displayName": "Anthropic Claude Opus 4.8",
             "iconUrl": "/anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions",
             "upstreams": [
               {
                 "endpoint": "%%AWS_BEDROCK_REGION%%",

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -33,36 +33,36 @@ core:
     aidial.config.json: |
       {
         "models": {
-            "gpt-5-2025-08-07": {
+            "gpt-chat-latest": {
               "type": "chat",
-              "displayName": "GPT-5",
-              "iconUrl": "/gpt5.svg",
-              "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-5-2025-08-07/chat/completions",
+              "displayName": "GPT Chat Latest",
+              "iconUrl": "gptchatlatest.svg",
+              "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-chat-latest/chat/completions",
               "upstreams": [
                 {
-                  "endpoint": "http://%%AZURE_DEPLOYMENT_HOST%%/openai/deployments/gpt-5-2025-08-07/chat/completions"
+                  "endpoint": "http://%%AZURE_DEPLOYMENT_HOST%%/openai/deployments/gpt-chat-latest/chat/completions"
                 }
               ]
           },
-          "gemini-2.5-pro": {
+          "gemini-chat-latest": {
             "type": "chat",
-            "displayName": "Gemini 2.5 Pro",
+            "displayName": "Google (Gemini)",
             "iconUrl": "/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-2.5-pro/chat/completions"
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-chat-latest/chat/completions"
           },
-          "anthropic.claude-opus-4-6-v1": {
+          "anthropic-chat-latest": {
               "type": "chat",
               "displayName": "Anthropic (Claude)",
               "iconUrl": "/anthropic.svg",
-              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/us.anthropic.claude-sonnet-4-6/chat/completions"
+              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic-chat-latest/chat/completions"
           }
         },
         "roles": {
           "chat": {
             "limits": {
-              "gpt-5-2025-08-07": {},
-              "gemini-2.5-pro": {},
-              "anthropic.claude-opus-4-6-v1": {}
+              "gpt-chat-latest": {},
+              "gemini-chat-latest": {},
+              "anthropic-chat-latest": {}
             }
           }
         }
@@ -97,7 +97,7 @@ chat:
     # -- External URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
     THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
-    DEFAULT_MODEL: "gpt-35-turbo-0301"
+    DEFAULT_MODEL: "gpt-chat-latest"
   secrets:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
     AUTH_AZURE_AD_CLIENT_ID: "%%AZURE_CLIENT_ID%%"

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -17,6 +17,7 @@ core:
     aidial.storage.bucket: "%%AZURE_CORE_BLOB_STORAGE_NAME%%"
     aidial.storage.endpoint: "%%AZURE_CORE_BLOB_STORAGE_ENDPOINT%%"
     aidial.storage.createBucket: "false"
+    aidial.storage.prefix: "core"
     aidial.storage.overrides: '{"jclouds.oauth.credential-type": "bearerTokenCredentials", "jclouds.azureblob.auth" : "azureAd"}'
     aidial.identityProviders.azure.loggingKey: "sub"
     aidial.identityProviders.azure.loggingSalt: "loggingSalt"
@@ -61,14 +62,7 @@ core:
             "type": "chat",
             "displayName": "Anthropic Claude Opus 4.8",
             "iconUrl": "/anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions",
-            "upstreams": [
-              {
-                "extraData": {
-                  "region": "%%AWS_BEDROCK_REGION%%"
-                }
-              }
-            ]
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
           }
         },
         "roles": {
@@ -96,6 +90,18 @@ core:
   valkey:
     enabled: false
 
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    annotations:
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
+    hosts:
+      - dial.%%DOMAIN%%
+    tls:
+      - secretName: "dial-tls-secret"
+        hosts:
+          - dial.%%DOMAIN%%
+
 chat:
   enabled: true
   env:
@@ -108,9 +114,9 @@ chat:
     # -- List of DIAL chat features to enable;
     # ref: https://github.com/epam/ai-dial-chat/blob/development/libs/shared/src/types/features.ts
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
-    # -- External URL of DIAL themes;
+    # -- External or Internal URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
-    THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
+    THEMES_CONFIG_HOST: "https://%%THEMES_CONFIG_HOST%%"
     DEFAULT_MODEL: "gpt-chat-latest"
   secrets:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
@@ -148,7 +154,7 @@ vertexai:
 
   env:
     GOOGLE_APPLICATION_CREDENTIALS: "/etc/workload-identity/credential-configuration.json"
-    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
     GCP_PROJECT_ID: "%%GCP_PROJECT_ID%%"
     DEFAULT_REGION: "%%GCP_REGION%%"
 
@@ -186,7 +192,7 @@ bedrock:
 
   env:
     AWS_DEFAULT_REGION: "%%AWS_REGION%%"
-    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
     AWS_ACCESS_KEY_ID: "%%AWS_ACCESS_KEY%%"
     AWS_SECRET_ACCESS_KEY: "%%AWS_SECRET_KEY%%"
 

--- a/charts/dial/examples/azure/complete/values.yaml
+++ b/charts/dial/examples/azure/complete/values.yaml
@@ -54,7 +54,7 @@ core:
               "type": "chat",
               "displayName": "Anthropic (Opus)",
               "iconUrl": "/anthropic.svg",
-              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic.claude-opus-4-8/chat/completions"
+              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
           }
         },
         "roles": {

--- a/charts/dial/examples/azure/simple/README.md
+++ b/charts/dial/examples/azure/simple/README.md
@@ -65,7 +65,6 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
-    - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - Replace `%%AZURE_CORE_CLIENT_ID%%` with managed identity client ID from [prerequisites](#prerequisites)
     - Replace `%%AZURE_CORE_BLOB_STORAGE_NAME%%` with Azure Blob storage name from [prerequisites](#prerequisites)
     - Replace `%%AZURE_CORE_BLOB_STORAGE_ENDPOINT%%` with Azure Blob storage endpoint from [prerequisites](#prerequisites)

--- a/charts/dial/examples/azure/simple/README.md
+++ b/charts/dial/examples/azure/simple/README.md
@@ -64,7 +64,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
-    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `https://not-a-real-endpoint.openai.azure.com/openai/v1/responses`
+    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
     - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - Replace `%%AZURE_CORE_CLIENT_ID%%` with managed identity client ID from [prerequisites](#prerequisites)
     - Replace `%%AZURE_CORE_BLOB_STORAGE_NAME%%` with Azure Blob storage name from [prerequisites](#prerequisites)

--- a/charts/dial/examples/azure/simple/README.md
+++ b/charts/dial/examples/azure/simple/README.md
@@ -12,6 +12,7 @@
 - AKS 1.24+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
+- [Ingress-Nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/) installed in the cluster
 - [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (optional)
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html)

--- a/charts/dial/examples/azure/simple/README.md
+++ b/charts/dial/examples/azure/simple/README.md
@@ -68,7 +68,6 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AZURE_CORE_BLOB_STORAGE_NAME%%` with Azure Blob storage name from [prerequisites](#prerequisites)
     - Replace `%%AZURE_CORE_BLOB_STORAGE_ENDPOINT%%` with Azure Blob storage endpoint from [prerequisites](#prerequisites)
     - It's assumed you've configured **external-dns** and **cert-manager** beforehand, so replace `%%CLUSTER_ISSUER%%` with your cluster issuer name, e.g. `letsencrypt-production`
-    - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
 1. Install `dial` helm chart in created namespace, applying custom values file:
 

--- a/charts/dial/examples/azure/simple/README.md
+++ b/charts/dial/examples/azure/simple/README.md
@@ -64,7 +64,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
-    - Replace `%%AZURE_MODEL_ENDPOINT%%` with Azure OpenAI Model Endpoint from [prerequisites](#prerequisites), e.g. `https://not-a-real-endpoint.openai.azure.com/openai/deployments/gpt-35-turbo/chat/completions`
+    - Replace `%%AZURE_MODEL_ENDPOINT%%` with Azure OpenAI Model Endpoint from [prerequisites](#prerequisites), e.g. `https://not-a-real-endpoint.openai.azure.com/openai/deployments/gpt-5-2025-08-07/chat/completions`
     - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - Replace `%%AZURE_CORE_CLIENT_ID%%` with managed identity client ID from [prerequisites](#prerequisites)
     - Replace `%%AZURE_CORE_BLOB_STORAGE_NAME%%` with Azure Blob storage name from [prerequisites](#prerequisites)

--- a/charts/dial/examples/azure/simple/README.md
+++ b/charts/dial/examples/azure/simple/README.md
@@ -22,8 +22,8 @@
 
 ## Expected Outcome
 
-By following the instructions in this guide, you will successfully install the AI DIAL system with configured connection to the Azure GPT-gpt-chat-latest API.\
-Please note that this guide represents a very basic deployment scenario, and **should never be used in production**.\
+By following the instructions in this guide, you will successfully install the AI DIAL system with configured connection to the Azure gpt-chat-latest API.
+Please note that this guide represents a very basic deployment scenario, and **should never be used in production**.
 Configuring authentication provider, encrypted secrets, model usage limits, Ingress allowlisting and other security measures are **out of scope** of this guide.
 
 ## Install

--- a/charts/dial/examples/azure/simple/README.md
+++ b/charts/dial/examples/azure/simple/README.md
@@ -11,9 +11,7 @@
 
 - AKS 1.24+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
-- [Gateway API CRD](https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-a-gateway-controller) installed in the cluster
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
-- [Ingress-Traefik Controller](https://doc.traefik.io/traefik/setup/kubernetes/) installed in the cluster
 - [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (optional)
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html)

--- a/charts/dial/examples/azure/simple/README.md
+++ b/charts/dial/examples/azure/simple/README.md
@@ -17,12 +17,12 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html)
 - [Azure Blob storage](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-overview)
-- [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview) `gpt-35-turbo` model deployed:
+- [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview) `gpt-chat-latest` model deployed:
   - [Azure Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/openai-model-deployment)
 
 ## Expected Outcome
 
-By following the instructions in this guide, you will successfully install the AI DIAL system with configured connection to the Azure GPT-3.5 API.\
+By following the instructions in this guide, you will successfully install the AI DIAL system with configured connection to the Azure GPT-gpt-chat-latest API.\
 Please note that this guide represents a very basic deployment scenario, and **should never be used in production**.\
 Configuring authentication provider, encrypted secrets, model usage limits, Ingress allowlisting and other security measures are **out of scope** of this guide.
 
@@ -64,7 +64,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
-    - Replace `%%AZURE_MODEL_ENDPOINT%%` with Azure OpenAI Model Endpoint from [prerequisites](#prerequisites), e.g. `https://not-a-real-endpoint.openai.azure.com/openai/deployments/gpt-5-2025-08-07/chat/completions`
+    - Replace `%%AZURE_MODEL_ENDPOINT%%` with Azure OpenAI Model Endpoint from [prerequisites](#prerequisites), e.g. `https://not-a-real-endpoint.openai.azure.com/openai/deployments/gpt-chat-latest/chat/completions`
     - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - Replace `%%AZURE_CORE_CLIENT_ID%%` with managed identity client ID from [prerequisites](#prerequisites)
     - Replace `%%AZURE_CORE_BLOB_STORAGE_NAME%%` with Azure Blob storage name from [prerequisites](#prerequisites)

--- a/charts/dial/examples/azure/simple/README.md
+++ b/charts/dial/examples/azure/simple/README.md
@@ -11,7 +11,7 @@
 
 - AKS 1.24+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
-- [Gateway API CRD](https://gateway-api.sigs.k8s.io/docs/concepts/api-overview/) installed in the cluster
+- [Gateway API CRD](https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-a-gateway-controller) installed in the cluster
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
 - [Ingress-Traefik Controller](https://doc.traefik.io/traefik/setup/kubernetes/) installed in the cluster
 - [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (optional)

--- a/charts/dial/examples/azure/simple/README.md
+++ b/charts/dial/examples/azure/simple/README.md
@@ -64,7 +64,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
-    - Replace `%%AZURE_MODEL_ENDPOINT%%` with Azure OpenAI Model Endpoint from [prerequisites](#prerequisites), e.g. `https://not-a-real-endpoint.openai.azure.com/openai/deployments/gpt-chat-latest/chat/completions`
+    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `https://not-a-real-endpoint.openai.azure.com/openai/v1/responses`
     - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - Replace `%%AZURE_CORE_CLIENT_ID%%` with managed identity client ID from [prerequisites](#prerequisites)
     - Replace `%%AZURE_CORE_BLOB_STORAGE_NAME%%` with Azure Blob storage name from [prerequisites](#prerequisites)

--- a/charts/dial/examples/azure/simple/README.md
+++ b/charts/dial/examples/azure/simple/README.md
@@ -11,8 +11,9 @@
 
 - AKS 1.24+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
+- [Gateway API CRD](https://gateway-api.sigs.k8s.io/docs/concepts/api-overview/) installed in the cluster
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
-- [Ingress-Nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/) installed in the cluster
+- [Ingress-Traefik Controller](https://doc.traefik.io/traefik/setup/kubernetes/) installed in the cluster
 - [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (optional)
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html)

--- a/charts/dial/examples/azure/simple/README.md
+++ b/charts/dial/examples/azure/simple/README.md
@@ -69,6 +69,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AZURE_CORE_BLOB_STORAGE_NAME%%` with Azure Blob storage name from [prerequisites](#prerequisites)
     - Replace `%%AZURE_CORE_BLOB_STORAGE_ENDPOINT%%` with Azure Blob storage endpoint from [prerequisites](#prerequisites)
     - It's assumed you've configured **external-dns** and **cert-manager** beforehand, so replace `%%CLUSTER_ISSUER%%` with your cluster issuer name, e.g. `letsencrypt-production`
+    - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
 1. Install `dial` helm chart in created namespace, applying custom values file:
 

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -73,16 +73,16 @@ core:
       aclUsers:
         default:
           password: "%%REDIS_PASSWORD%%"
-
+  
   ingress:
     enabled: true
-    ingressClassName: nginx
+    ingressClassName: traefik
     annotations:
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%" # To issue ssl certificate
     hosts:
       - dial.%%DOMAIN%%
     tls:
-      - secretName: "dial-tls-secret"
+      - secretName: "dial-tls"
         hosts:
           - dial.%%DOMAIN%%
 
@@ -94,7 +94,7 @@ chat:
     NEXTAUTH_URL: "https://chat.%%DOMAIN%%"
     # -- DIAL core API endpoint
     # Internal service name (DNS name) of DIAL core service
-    DIAL_API_HOST: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_API_HOST: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
     # -- List of DIAL chat features to enable;
     # ref: https://github.com/epam/ai-dial-chat/blob/development/libs/shared/src/types/features.ts
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
@@ -106,33 +106,29 @@ chat:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
     # -- API key defined in core configuration
     DIAL_API_KEY: "%%DIAL_API_KEY%%"
+
   ingress:
     enabled: true
-    ingressClassName: nginx
+    ingressClassName: traefik
     annotations:
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%" # To issue ssl certificate
     hosts:
       - chat.%%DOMAIN%%
     tls:
-      - secretName: "chat-tls-secret"
+      - secretName: "chat-tls"
         hosts:
           - chat.%%DOMAIN%%
 
 themes:
   enabled: true
-  ingress:
+  httpRoute:
     enabled: true
-    ingressClassName: nginx
-    path: "/themes/(.*)"
-    annotations:
-      nginx.ingress.kubernetes.io/rewrite-target: "/$1"
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
-    hosts:
-      - dial.%%DOMAIN%%
-    tls:
-      - secretName: "dial-tls-secret"
-        hosts:
-          - dial.%%DOMAIN%%
+    parentRefs:
+      - name: traefik
+        namespace: traefik
+        sectionName: websecure
+    hostnames:
+      - themes.%%DOMAIN%%
 
 openai:
   enabled: true

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -109,26 +109,31 @@ chat:
 
   ingress:
     enabled: true
-    ingressClassName: traefik
+    ingressClassName: nginx
     annotations:
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%" # To issue ssl certificate
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
     hosts:
-      - chat.%%DOMAIN%%
+      - dial.%%DOMAIN%%
     tls:
-      - secretName: "chat-tls"
+      - secretName: "dial-tls-secret"
         hosts:
-          - chat.%%DOMAIN%%
+          - dial.%%DOMAIN%%
 
 themes:
   enabled: true
-  httpRoute:
+  ingress:
     enabled: true
-    parentRefs:
-      - name: traefik
-        namespace: traefik
-        sectionName: websecure
-    hostnames:
-      - themes.%%DOMAIN%%
+    ingressClassName: nginx
+    path: "/themes/(.*)"
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: "/$1"
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
+    hosts:
+      - dial.%%DOMAIN%%
+    tls:
+      - secretName: "dial-tls-secret"
+        hosts:
+          - dial.%%DOMAIN%%
 
 openai:
   enabled: true

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -72,7 +72,6 @@ core:
       enabled: true
       aclUsers:
         default:
-          permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
   
   ingress:

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -77,7 +77,7 @@ core:
   
   ingress:
     enabled: true
-    ingressClassName: traefik
+    ingressClassName: nginx
     annotations:
       cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%" # To issue ssl certificate
     hosts:

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -33,6 +33,16 @@ core:
             "displayName": "GPT Chat Latest",
             "iconUrl": "gpt4.svg",
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
+            "auth": {
+              "type": "bearer",
+              "apiKeyEnv": "%%AZURE_MODEL_KEY%%",
+              "header": "Authorization",
+              "prefix": "Bearer "
+            },
+            "provider": {
+              "name": "openai-compatible",
+              "requiresApiKey": true
+            },
             "upstreams": [
               {
                 "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -72,7 +72,7 @@ core:
       enabled: true
       aclUsers:
         default:
-          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
+          permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
   
   ingress:

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -29,26 +29,16 @@ core:
       {
         "models": {
           "gpt-chat-latest": {
-            "type": "chat",
-            "displayName": "GPT Chat Latest",
-            "iconUrl": "gpt4.svg",
-            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
-            "auth": {
-              "type": "bearer",
-              "apiKeyEnv": "%%AZURE_MODEL_KEY%%",
-              "header": "Authorization",
-              "prefix": "Bearer "
-            },
-            "provider": {
-              "name": "openai-compatible",
-              "requiresApiKey": true
-            },
-            "upstreams": [
-              {
-                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
-              }
-            ]
-          }
+          "type": "chat",
+          "displayName": "GPT Chat Latest",
+          "iconUrl": "gpt4.svg",
+          "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
+          "upstreams": [
+            {
+              "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses",
+              "key": "%%AZURE_MODEL_KEY%%"
+            }
+          ]
         },
         "keys": {
           "%%DIAL_API_KEY%%": {

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -101,7 +101,7 @@ chat:
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
     # -- External or Internal URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
-    THEMES_CONFIG_HOST: "https://%%THEMES_CONFIG_HOST%%"
+    THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
     DEFAULT_MODEL: "gpt-chat-latest"
   secrets:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
@@ -122,19 +122,6 @@ chat:
 
 themes:
   enabled: true
-  ingress:
-    enabled: true
-    ingressClassName: nginx
-    path: "/themes/(.*)"
-    annotations:
-      nginx.ingress.kubernetes.io/rewrite-target: "/$1"
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
-    hosts:
-      - dial.%%DOMAIN%%
-    tls:
-      - secretName: "dial-tls-secret"
-        hosts:
-          - dial.%%DOMAIN%%
 
 openai:
   enabled: true

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -83,7 +83,7 @@ core:
     hosts:
       - dial.%%DOMAIN%%
     tls:
-      - secretName: "dial-tls"
+      - secretName: "dial-tls-secret"
         hosts:
           - dial.%%DOMAIN%%
 
@@ -116,7 +116,7 @@ chat:
     hosts:
       - chat.%%DOMAIN%%
     tls:
-      - secretName: "dial-tls-secret"
+      - secretName: "chat-tls-secret"
         hosts:
           - chat.%%DOMAIN%%
 

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -134,4 +134,4 @@ openai:
   enabled: true
 
   env:
-    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -31,12 +31,11 @@ core:
           "gpt-chat-latest": {
             "type": "chat",
             "displayName": "GPT Chat Latest",
-            "iconUrl": "https://dial.%%DOMAIN%%/themes/gptchatlatest.svg",
+            "iconUrl": "gpt4.svg",
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
             "upstreams": [
               {
-                "endpoint": "%%AZURE_MODEL_ENDPOINT%%",
-                "key": "%%AZURE_MODEL_KEY%%"
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
               }
             ]
           }

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -28,11 +28,11 @@ core:
     aidial.config.json: |
       {
         "models": {
-          "gpt-35-turbo": {
+          "gpt-5-2025-08-07": {
             "type": "chat",
-            "displayName": "GPT-3.5",
+            "displayName": "GPT-5",
             "iconUrl": "https://dial.%%DOMAIN%%/themes/gpt3.svg",
-            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-35-turbo/chat/completions",
+            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-5-2025-08-07/chat/completions",
             "upstreams": [
               {
                 "endpoint": "%%AZURE_MODEL_ENDPOINT%%",
@@ -50,7 +50,7 @@ core:
         "roles": {
           "chat": {
             "limits": {
-              "gpt-35-turbo": {}
+              "gpt-5-2025-08-07": {}
             }
           }
         }
@@ -67,9 +67,13 @@ core:
       mountPath: "/mnt/secrets-store/aidial.config.json"
       subPath: aidial.config.json
       readOnly: true
-  redis:
+  valkey:
     enabled: true
-    password: "%%REDIS_PASSWORD%%"
+    auth:
+      enabled: true
+      aclUsers:
+        default:
+          password: "%%REDIS_PASSWORD%%"
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -35,8 +35,7 @@ core:
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
             "upstreams": [
               {
-                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses",
-                "key": "%%AZURE_MODEL_KEY%%"
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
               }
             ]
           }

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -72,8 +72,8 @@ core:
       enabled: true
       aclUsers:
         default:
-          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
+
   ingress:
     enabled: true
     ingressClassName: nginx
@@ -94,13 +94,14 @@ chat:
     NEXTAUTH_URL: "https://chat.%%DOMAIN%%"
     # -- DIAL core API endpoint
     # Internal service name (DNS name) of DIAL core service
-    DIAL_API_HOST: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_API_HOST: "http://core.%%NAMESPACE%%.svc.cluster.local"
     # -- List of DIAL chat features to enable;
     # ref: https://github.com/epam/ai-dial-chat/blob/development/libs/shared/src/types/features.ts
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
-    # -- External URL of DIAL themes;
+    # -- External or Internal URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
-    THEMES_CONFIG_HOST: "https://dial.%%DOMAIN%%/themes"
+    THEMES_CONFIG_HOST: "https://%%THEMES_CONFIG_HOST%%"
+    DEFAULT_MODEL: "gpt-chat-latest"
   secrets:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
     # -- API key defined in core configuration
@@ -137,4 +138,4 @@ openai:
   enabled: true
 
   env:
-    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -73,6 +73,7 @@ core:
       enabled: true
       aclUsers:
         default:
+          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
   ingress:
     enabled: true

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -114,11 +114,11 @@ chat:
     annotations:
       cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
     hosts:
-      - dial.%%DOMAIN%%
+      - chat.%%DOMAIN%%
     tls:
       - secretName: "dial-tls-secret"
         hosts:
-          - dial.%%DOMAIN%%
+          - chat.%%DOMAIN%%
 
 themes:
   enabled: true

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -72,6 +72,7 @@ core:
       enabled: true
       aclUsers:
         default:
+          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
   
   ingress:

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -29,16 +29,17 @@ core:
       {
         "models": {
           "gpt-chat-latest": {
-          "type": "chat",
-          "displayName": "GPT Chat Latest",
-          "iconUrl": "gpt4.svg",
-          "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
-          "upstreams": [
-            {
-              "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses",
-              "key": "%%AZURE_MODEL_KEY%%"
-            }
-          ]
+            "type": "chat",
+            "displayName": "GPT Chat Latest",
+            "iconUrl": "gpt4.svg",
+            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
+            "upstreams": [
+              {
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses",
+                "key": "%%AZURE_MODEL_KEY%%"
+              }
+            ]
+          }
         },
         "keys": {
           "%%DIAL_API_KEY%%": {

--- a/charts/dial/examples/azure/simple/values.yaml
+++ b/charts/dial/examples/azure/simple/values.yaml
@@ -28,11 +28,11 @@ core:
     aidial.config.json: |
       {
         "models": {
-          "gpt-5-2025-08-07": {
+          "gpt-chat-latest": {
             "type": "chat",
-            "displayName": "GPT-5",
-            "iconUrl": "https://dial.%%DOMAIN%%/themes/gpt3.svg",
-            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-5-2025-08-07/chat/completions",
+            "displayName": "GPT Chat Latest",
+            "iconUrl": "https://dial.%%DOMAIN%%/themes/gptchatlatest.svg",
+            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
             "upstreams": [
               {
                 "endpoint": "%%AZURE_MODEL_ENDPOINT%%",
@@ -50,7 +50,7 @@ core:
         "roles": {
           "chat": {
             "limits": {
-              "gpt-5-2025-08-07": {}
+              "gpt-chat-latest": {}
             }
           }
         }

--- a/charts/dial/examples/gcp/complete/README.md
+++ b/charts/dial/examples/gcp/complete/README.md
@@ -30,7 +30,7 @@
   - [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 - [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview)
   - [OpenAI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/openai-model-deployment)
-- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic.claude-opus-4-8` model deployed:
+- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `global.anthropic.claude-opus-4-8` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/gcp/complete/README.md
+++ b/charts/dial/examples/gcp/complete/README.md
@@ -26,11 +26,11 @@
   - [Downloading the Certificate Authority](https://cloud.google.com/memorystore/docs/redis/manage-in-transit-encryption#downloading_the_certificate_authority)
   - [Creating TrustStore](https://docs.oracle.com/cd/E19509-01/820-3503/ggfka/index.html)
 - [Google Identity](https://docs.dialx.ai/tutorials/devops/auth-and-access-control/configure-idps/google) as identity provider
-- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-1.5-pro` model deployed:
+- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-chat-latest` model deployed:
   - [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 - [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview)
   - [OpenAI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/openai-model-deployment)
-- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic.claude-v1` model deployed:
+- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic-chat-latest` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/gcp/complete/README.md
+++ b/charts/dial/examples/gcp/complete/README.md
@@ -15,7 +15,8 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [GCP IAM roles for service accounts](https://cloud.google.com/iam/docs/service-account-overview) installed and configured
 - [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html) installed and configured
-- [AWS IAM credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/getting-started-workloads.html) configured
+- [AWS IAM role for Bedrock access](https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.html) configured
+- [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook) installed in the cluster with the `--aws-default-region` flag set (required to inject `AWS_DEFAULT_REGION` into the Bedrock pod)
 - [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) installed and configured
 - [GKE Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) installed
 - [Static IP address](https://cloud.google.com/vpc/docs/reserve-static-external-ip-address) reserved for Chat and Core
@@ -89,11 +90,9 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AUTH_GOOGLE_CLIENT_ID%%` with Cloud Identity client ID from [prerequisites](#prerequisites)
     - Replace `%%AUTH_GOOGLE_SECRET%%` with Cloud Identity client secret from [prerequisites](#prerequisites)
     - Replace `%%GCP_VERTEXAI_SERVICE_ACCOUNT%%` with Google Service Account from [prerequisites](#prerequisites)
-    - Replace `%%AWS_ACCESS_KEY%%` with AWS access key from [prerequisites](#prerequisites)
-    - Replace `%%AWS_SECRET_KEY%%` with AWS secret key from [prerequisites](#prerequisites)
+    - Replace `%%AWS_BEDROCK_ROLE_ARN%%` with bedrock AWS role ARN from [prerequisites](#prerequisites)
     - Replace `%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%` with appropriate workload identity from [prerequisites](#prerequisites)
     - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
-    - Replace `%%AWS_BEDROCK_REGION%%` with bedrock region from [prerequisites](#prerequisites)
     - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
 1. Install `dial` helm chart in created namespace, applying custom values file:

--- a/charts/dial/examples/gcp/complete/README.md
+++ b/charts/dial/examples/gcp/complete/README.md
@@ -93,7 +93,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AWS_ACCESS_KEY%%` with AWS access key from [prerequisites](#prerequisites)
     - Replace `%%AWS_SECRET_KEY%%` with AWS secret key from [prerequisites](#prerequisites)
     - Replace `%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%` with appropriate workload identity from [prerequisites](#prerequisites)
-    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `https://not-a-real-endpoint.openai.azure.com/openai/v1/responses`
+    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
     - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - Replace `%%AWS_BEDROCK_REGION%%` with bedrock region from [prerequisites](#prerequisites)
 

--- a/charts/dial/examples/gcp/complete/README.md
+++ b/charts/dial/examples/gcp/complete/README.md
@@ -16,6 +16,7 @@
 - [GCP IAM roles for service accounts](https://cloud.google.com/iam/docs/service-account-overview) installed and configured
 - [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html) installed and configured
 - [AWS IAM credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/getting-started-workloads.html) configured
+- [AWS Bedrock Regional availability by models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-region-compatibility.html)
 - [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) installed and configured
 - [GKE Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) installed
 - [Static IP address](https://cloud.google.com/vpc/docs/reserve-static-external-ip-address) reserved for Chat and Core
@@ -92,6 +93,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AWS_ACCESS_KEY%%` with AWS access key from [prerequisites](#prerequisites)
     - Replace `%%AWS_SECRET_KEY%%` with AWS secret key from [prerequisites](#prerequisites)
     - Replace `%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%` with appropriate workload identity from [prerequisites](#prerequisites)
+    - Replace `%%AWS_BEDROCK_REGION%%` with bedrock region from [prerequisites](#prerequisites)
 
 1. Install `dial` helm chart in created namespace, applying custom values file:
 

--- a/charts/dial/examples/gcp/complete/README.md
+++ b/charts/dial/examples/gcp/complete/README.md
@@ -93,6 +93,8 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AWS_ACCESS_KEY%%` with AWS access key from [prerequisites](#prerequisites)
     - Replace `%%AWS_SECRET_KEY%%` with AWS secret key from [prerequisites](#prerequisites)
     - Replace `%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%` with appropriate workload identity from [prerequisites](#prerequisites)
+    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `https://not-a-real-endpoint.openai.azure.com/openai/v1/responses`
+    - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - Replace `%%AWS_BEDROCK_REGION%%` with bedrock region from [prerequisites](#prerequisites)
 
 1. Install `dial` helm chart in created namespace, applying custom values file:

--- a/charts/dial/examples/gcp/complete/README.md
+++ b/charts/dial/examples/gcp/complete/README.md
@@ -94,7 +94,6 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AWS_SECRET_KEY%%` with AWS secret key from [prerequisites](#prerequisites)
     - Replace `%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%` with appropriate workload identity from [prerequisites](#prerequisites)
     - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
-    - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - Replace `%%AWS_BEDROCK_REGION%%` with bedrock region from [prerequisites](#prerequisites)
 
 1. Install `dial` helm chart in created namespace, applying custom values file:

--- a/charts/dial/examples/gcp/complete/README.md
+++ b/charts/dial/examples/gcp/complete/README.md
@@ -16,7 +16,6 @@
 - [GCP IAM roles for service accounts](https://cloud.google.com/iam/docs/service-account-overview) installed and configured
 - [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html) installed and configured
 - [AWS IAM credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/getting-started-workloads.html) configured
-- [AWS Bedrock Regional availability by models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-region-compatibility.html)
 - [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) installed and configured
 - [GKE Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) installed
 - [Static IP address](https://cloud.google.com/vpc/docs/reserve-static-external-ip-address) reserved for Chat and Core
@@ -95,6 +94,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%` with appropriate workload identity from [prerequisites](#prerequisites)
     - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
     - Replace `%%AWS_BEDROCK_REGION%%` with bedrock region from [prerequisites](#prerequisites)
+    - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
 1. Install `dial` helm chart in created namespace, applying custom values file:
 

--- a/charts/dial/examples/gcp/complete/README.md
+++ b/charts/dial/examples/gcp/complete/README.md
@@ -93,7 +93,6 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%AWS_BEDROCK_ROLE_ARN%%` with bedrock AWS role ARN from [prerequisites](#prerequisites)
     - Replace `%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%` with appropriate workload identity from [prerequisites](#prerequisites)
     - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
-    - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
 1. Install `dial` helm chart in created namespace, applying custom values file:
 

--- a/charts/dial/examples/gcp/complete/README.md
+++ b/charts/dial/examples/gcp/complete/README.md
@@ -26,11 +26,11 @@
   - [Downloading the Certificate Authority](https://cloud.google.com/memorystore/docs/redis/manage-in-transit-encryption#downloading_the_certificate_authority)
   - [Creating TrustStore](https://docs.oracle.com/cd/E19509-01/820-3503/ggfka/index.html)
 - [Google Identity](https://docs.dialx.ai/tutorials/devops/auth-and-access-control/configure-idps/google) as identity provider
-- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-chat-latest` model deployed:
+- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-3.5-flash` model deployed:
   - [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 - [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview)
   - [OpenAI Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/openai-model-deployment)
-- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic-chat-latest` model deployed:
+- [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) `anthropic.claude-opus-4-8` model deployed:
   - [Bedrock Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/bedrock-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -36,6 +36,16 @@ core:
             "displayName": "GPT Chat Latest",
             "iconUrl": "gpt4.svg",
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
+            "auth": {
+              "type": "bearer",
+              "apiKeyEnv": "%%AZURE_MODEL_KEY%%",
+              "header": "Authorization",
+              "prefix": "Bearer "
+            },
+            "provider": {
+              "name": "openai-compatible",
+              "requiresApiKey": true
+            },
             "upstreams": [
               {
                 "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -59,14 +59,7 @@ core:
             "type": "chat",
             "displayName": "Anthropic Claude Opus 4.8",
             "iconUrl": "/anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions",
-            "upstreams": [
-              {
-                "extraData": {
-                  "region": "%%AWS_BEDROCK_REGION%%"
-                }
-              }
-            ]
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
           }
         },
         "roles": {
@@ -121,13 +114,13 @@ chat:
     NEXTAUTH_URL: "https://chat.%%DOMAIN%%"
     # -- DIAL core API endpoint
     # Internal service name (DNS name) of DIAL core service
-    DIAL_API_HOST: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_API_HOST: "http://core.%%NAMESPACE%%.svc.cluster.local"
     # -- List of DIAL chat features to enable;
     # ref: https://github.com/epam/ai-dial-chat/blob/development/libs/shared/src/types/features.ts
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
-    # -- External URL of DIAL themes;
+    # -- External or Internal URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
-    THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
+    THEMES_CONFIG_HOST: "https://%%THEMES_CONFIG_HOST%%"
     DEFAULT_MODEL: "gemini-3.5-flash"
     AUTH_GOOGLE_CLIENT_ID: "%%AUTH_GOOGLE_CLIENT_ID%%"
     AUTH_GOOGLE_SECRET: "%%AUTH_GOOGLE_SECRET%%"
@@ -161,7 +154,7 @@ vertexai:
       iam.gke.io/gcp-service-account: "%%GCP_VERTEXAI_SERVICE_ACCOUNT%%"
 
   env:
-    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
     GCP_PROJECT_ID: "%%GCP_PROJECT_ID%%"
     DEFAULT_REGION: "%%GCP_REGION%%"
 
@@ -172,6 +165,7 @@ bedrock:
     DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
     AWS_ACCESS_KEY_ID: "%%AWS_ACCESS_KEY%%"
     AWS_SECRET_ACCESS_KEY: "%%AWS_SECRET_KEY%%"
+    AWS_DEFAULT_REGION: "%%AWS_BEDROCK_REGION%%"
 
   serviceAccount:
     create: true

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -42,25 +42,25 @@ core:
               }
             ]
           },
-          "gemini-chat-latest": {
+          "gemini-3.5-flash": {
             "type": "chat",
             "displayName": "Google (Gemini)",
             "iconUrl": "/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-chat-latest/chat/completions"
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions"
           },
-          "anthropic-chat-latest": {
+          "anthropic.claude-opus-4-8": {
             "type": "chat",
-            "displayName": "Anthropic (Claude)",
+            "displayName": "Anthropic (Opus)",
             "iconUrl": "/anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic-chat-latest/chat/completions"
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic.claude-opus-4-8/chat/completions"
           }
         },
         "roles": {
           "chat": {
             "limits": {
               "gpt-chat-latest": {},
-              "gemini-chat-latest": {},
-              "anthropic-chat-latest": {}
+              "gemini-3.5-flash": {},
+              "anthropic.claude-opus-4-8": {}
             }
           }
         }
@@ -114,7 +114,7 @@ chat:
     # -- External URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
     THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
-    DEFAULT_MODEL: "gemini-chat-latest"
+    DEFAULT_MODEL: "gemini-3.5-flash"
     AUTH_GOOGLE_CLIENT_ID: "%%AUTH_GOOGLE_CLIENT_ID%%"
     AUTH_GOOGLE_SECRET: "%%AUTH_GOOGLE_SECRET%%"
     AUTH_GOOGLE_SCOPE: "openid email profile https://www.googleapis.com/auth/cloud-identity.groups.readonly"

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -35,10 +35,10 @@ core:
             "type": "chat",
             "displayName": "GPT Chat Latest",
             "iconUrl": "gptchatlatest.svg",
-            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-chat-latest/chat/completions",
+            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
             "upstreams": [
               {
-                "endpoint": "http://%%AZURE_DEPLOYMENT_HOST%%/openai/deployments/gpt-chat-latest/chat/completions"
+                  "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
               }
             ]
           },
@@ -50,9 +50,18 @@ core:
           },
           "anthropic.claude-opus-4-8": {
             "type": "chat",
-            "displayName": "Anthropic (Opus)",
+            "displayName": "Anthropic Claude Opus 4.8",
             "iconUrl": "/anthropic.svg",
             "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
+            "upstreams": [
+              {
+                  "endpoint": "%%AWS_BEDROCK_REGION%%",
+                  "extraData": {
+                      "region": "%%AWS_BEDROCK_REGION%%",
+                      "compatible_model_id": "anthropic.claude-opus-4-6-v1"
+                  }
+              }
+            ]
           }
         },
         "roles": {

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -38,8 +38,7 @@ core:
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
             "upstreams": [
               {
-                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses",
-                "key": "%%AZURE_MODEL_KEY%%"
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
               }
             ]
           },

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -31,36 +31,36 @@ core:
     aidial.config.json: |
       {
         "models": {
-          "gpt-5-2025-08-07": {
+          "gpt-chat-latest": {
             "type": "chat",
-            "displayName": "GPT-5",
-            "iconUrl": "/gpt5.svg",
-            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-5-2025-08-07/chat/completions",
+            "displayName": "GPT Chat Latest",
+            "iconUrl": "gptchatlatest.svg",
+            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-chat-latest/chat/completions",
             "upstreams": [
               {
-                "endpoint": "http://%%AZURE_DEPLOYMENT_HOST%%/openai/deployments/gpt-5-2025-08-07/chat/completions"
+                "endpoint": "http://%%AZURE_DEPLOYMENT_HOST%%/openai/deployments/gpt-chat-latest/chat/completions"
               }
             ]
           },
-          "gemini-2.5-pro": {
+          "gemini-chat-latest": {
             "type": "chat",
-            "displayName": "Gemini 2.5 Pro",
+            "displayName": "Google (Gemini)",
             "iconUrl": "/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-2.5-pro/chat/completions"
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-chat-latest/chat/completions"
           },
-          "anthropic.claude-opus-4-6-v1": {
+          "anthropic-chat-latest": {
             "type": "chat",
             "displayName": "Anthropic (Claude)",
             "iconUrl": "/anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/us.anthropic.claude-sonnet-4-6/chat/completions"
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic-chat-latest/chat/completions"
           }
         },
         "roles": {
           "chat": {
             "limits": {
-              "gpt-5-2025-08-07": {},
-              "gemini-2.5-pro": {},
-              "anthropic.claude-opus-4-6-v1": {}
+              "gpt-chat-latest": {},
+              "gemini-chat-latest": {},
+              "anthropic-chat-latest": {}
             }
           }
         }
@@ -114,7 +114,7 @@ chat:
     # -- External URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
     THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
-    DEFAULT_MODEL: "gemini-2.5-pro"
+    DEFAULT_MODEL: "gemini-chat-latest"
     AUTH_GOOGLE_CLIENT_ID: "%%AUTH_GOOGLE_CLIENT_ID%%"
     AUTH_GOOGLE_SECRET: "%%AUTH_GOOGLE_SECRET%%"
     AUTH_GOOGLE_SCOPE: "openid email profile https://www.googleapis.com/auth/cloud-identity.groups.readonly"

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -45,7 +45,7 @@ core:
           "gemini-3.5-flash": {
             "type": "chat",
             "displayName": "Google (Gemini)",
-            "iconUrl": "/Gemini.svg",
+            "iconUrl": "Gemini.svg",
             "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions",
             "upstreams": [
               {
@@ -58,7 +58,7 @@ core:
           "anthropic.claude-opus-4-8": {
             "type": "chat",
             "displayName": "Anthropic Claude Opus 4.8",
-            "iconUrl": "/anthropic.svg",
+            "iconUrl": "anthropic.svg",
             "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
           }
         },
@@ -120,7 +120,7 @@ chat:
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
     # -- External or Internal URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
-    THEMES_CONFIG_HOST: "https://%%THEMES_CONFIG_HOST%%"
+    THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
     DEFAULT_MODEL: "gemini-3.5-flash"
     AUTH_GOOGLE_CLIENT_ID: "%%AUTH_GOOGLE_CLIENT_ID%%"
     AUTH_GOOGLE_SECRET: "%%AUTH_GOOGLE_SECRET%%"
@@ -141,8 +141,6 @@ chat:
 
 themes:
   enabled: true
-  ingress:
-    enabled: false
 
 vertexai:
   enabled: true

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -52,7 +52,7 @@ core:
             "type": "chat",
             "displayName": "Anthropic (Opus)",
             "iconUrl": "/anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic.claude-opus-4-8/chat/completions"
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
           }
         },
         "roles": {

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -52,7 +52,7 @@ core:
             "type": "chat",
             "displayName": "Anthropic Claude Opus 4.8",
             "iconUrl": "/anthropic.svg",
-            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions",
             "upstreams": [
               {
                 "endpoint": "%%AWS_BEDROCK_REGION%%",

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -63,7 +63,6 @@ core:
             "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions",
             "upstreams": [
               {
-                "endpoint": "%%AWS_BEDROCK_REGION%%",
                 "extraData": {
                   "region": "%%AWS_BEDROCK_REGION%%"
                 }

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -163,12 +163,14 @@ bedrock:
 
   env:
     DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
-    AWS_ACCESS_KEY_ID: "%%AWS_ACCESS_KEY%%"
-    AWS_SECRET_ACCESS_KEY: "%%AWS_SECRET_KEY%%"
-    AWS_DEFAULT_REGION: "%%AWS_BEDROCK_REGION%%"
+
+  podLabels:
+    eks.amazonaws.com/pod-identity-webhook: "true"
 
   serviceAccount:
     create: true
+    annotations:
+      eks.amazonaws.com/role-arn: "%%AWS_BEDROCK_ROLE_ARN%%"
 
 openai:
   enabled: true

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -54,7 +54,7 @@ core:
                   "region": "global"
                 }
               }
-            ],
+            ]
           },
           "anthropic.claude-opus-4-8": {
             "type": "chat",

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -34,11 +34,11 @@ core:
           "gpt-chat-latest": {
             "type": "chat",
             "displayName": "GPT Chat Latest",
-            "iconUrl": "gptchatlatest.svg",
+            "iconUrl": "gpt4.svg",
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
             "upstreams": [
               {
-                  "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
               }
             ]
           },
@@ -55,11 +55,10 @@ core:
             "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/global.anthropic.claude-opus-4-8/chat/completions"
             "upstreams": [
               {
-                  "endpoint": "%%AWS_BEDROCK_REGION%%",
-                  "extraData": {
-                      "region": "%%AWS_BEDROCK_REGION%%",
-                      "compatible_model_id": "anthropic.claude-opus-4-6-v1"
-                  }
+                "endpoint": "%%AWS_BEDROCK_REGION%%",
+                "extraData": {
+                  "region": "%%AWS_BEDROCK_REGION%%"
+                }
               }
             ]
           }

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -31,36 +31,36 @@ core:
     aidial.config.json: |
       {
         "models": {
-            "gpt-4": {
-              "type": "chat",
-              "displayName": "GPT-4",
-              "iconUrl": "/gpt4.svg",
-              "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-4-0613/chat/completions",
-              "upstreams": [
-                  {
-                      "endpoint": "http://%%AZURE_DEPLOYMENT_HOST%%/openai/deployments/gpt-4/chat/completions"
-                  }
-              ]
-          },
-          "gemini-1.5-pro": {
+          "gpt-5-2025-08-07": {
             "type": "chat",
-            "displayName": "Gemini 1.5 Pro",
-            "iconUrl": "/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-pro/chat/completions"
+            "displayName": "GPT-5",
+            "iconUrl": "/gpt5.svg",
+            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local.:80/openai/deployments/gpt-5-2025-08-07/chat/completions",
+            "upstreams": [
+              {
+                "endpoint": "http://%%AZURE_DEPLOYMENT_HOST%%/openai/deployments/gpt-5-2025-08-07/chat/completions"
+              }
+            ]
           },
-          "anthropic.claude-v2:1": {
-              "type": "chat",
-              "displayName": "Anthropic (Claude)",
-              "iconUrl": "/anthropic.svg",
-              "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/anthropic.claude-v1/chat/completions"
+          "gemini-2.5-pro": {
+            "type": "chat",
+            "displayName": "Gemini 2.5 Pro",
+            "iconUrl": "/Gemini.svg",
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-2.5-pro/chat/completions"
+          },
+          "anthropic.claude-opus-4-6-v1": {
+            "type": "chat",
+            "displayName": "Anthropic (Claude)",
+            "iconUrl": "/anthropic.svg",
+            "endpoint": "http://dial-bedrock.%%NAMESPACE%%.svc.cluster.local/openai/deployments/us.anthropic.claude-sonnet-4-6/chat/completions"
           }
         },
         "roles": {
           "chat": {
             "limits": {
-              "gpt-4": {},
-              "gemini-1.5-pro": {},
-              "anthropic.claude-v2:1": {}
+              "gpt-5-2025-08-07": {},
+              "gemini-2.5-pro": {},
+              "anthropic.claude-opus-4-6-v1": {}
             }
           }
         }
@@ -87,7 +87,7 @@ core:
       mountPath: "/mnt/secrets-store/redis-truststore.jks"
       subPath: redis-truststore.jks
       readOnly: true
-  redis:
+  valkey:
     enabled: false
   ingress:
     enabled: true
@@ -114,7 +114,7 @@ chat:
     # -- External URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
     THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
-    DEFAULT_MODEL: "gemini-1.5-pro"
+    DEFAULT_MODEL: "gemini-2.5-pro"
     AUTH_GOOGLE_CLIENT_ID: "%%AUTH_GOOGLE_CLIENT_ID%%"
     AUTH_GOOGLE_SECRET: "%%AUTH_GOOGLE_SECRET%%"
     AUTH_GOOGLE_SCOPE: "openid email profile https://www.googleapis.com/auth/cloud-identity.groups.readonly"

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -21,13 +21,13 @@ core:
     aidial.identityProviders.google.userInfoEndpoint: "https://openidconnect.googleapis.com/v1/userinfo"
     aidial.identityProviders.google.rolePath: "fn:getGoogleWorkspaceGroups"
     aidial.identityProviders.google.loggingKey: "sub"
-    aidial.identityProviders.google.loggingSalt: "loggingSalt"
     aidial.redis.provider.name: "gcp-memory-store"
     aidial.redis.provider.accountName: "projects/-/serviceAccounts/%%GCP_CORE_SERVICE_ACCOUNT%%"
     aidial.redis.clusterServersConfig.nodeAddresses: "%%GCP_MEMORYSTORE_REDISCLUSTER_ENDPOINT%%"
     aidial.redis.clusterServersConfig.sslTruststore: "file:///mnt/secrets-store/redis-truststore.jks"
     aidial.redis.clusterServersConfig.sslTruststorePassword: "%%TRUSTSTORE_PASSWORD%%"
   secrets:
+    aidial.identityProviders.google.loggingSalt: "loggingSalt"
     aidial.config.json: |
       {
         "models": {
@@ -180,7 +180,7 @@ openai:
     azure.workload.identity/use: "true"
 
   serviceAccount:
-    enabled: true
+    create: true
     name: dial-openai
     annotations:
       azure.workload.identity/client-id: "%%AZURE_WORKLOAD_IDENTITY_CLIENT_ID%%"

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -36,19 +36,10 @@ core:
             "displayName": "GPT Chat Latest",
             "iconUrl": "gpt4.svg",
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
-            "auth": {
-              "type": "bearer",
-              "apiKeyEnv": "%%AZURE_MODEL_KEY%%",
-              "header": "Authorization",
-              "prefix": "Bearer "
-            },
-            "provider": {
-              "name": "openai-compatible",
-              "requiresApiKey": true
-            },
             "upstreams": [
               {
-                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses",
+                "key": "%%AZURE_MODEL_KEY%%"
               }
             ]
           },
@@ -56,7 +47,14 @@ core:
             "type": "chat",
             "displayName": "Google (Gemini)",
             "iconUrl": "/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions"
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions",
+            "upstreams": [
+              {
+                "extraData": {
+                  "region": "global"
+                }
+              }
+            ],
           },
           "anthropic.claude-opus-4-8": {
             "type": "chat",

--- a/charts/dial/examples/gcp/complete/values.yaml
+++ b/charts/dial/examples/gcp/complete/values.yaml
@@ -114,7 +114,7 @@ chat:
     NEXTAUTH_URL: "https://chat.%%DOMAIN%%"
     # -- DIAL core API endpoint
     # Internal service name (DNS name) of DIAL core service
-    DIAL_API_HOST: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_API_HOST: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
     # -- List of DIAL chat features to enable;
     # ref: https://github.com/epam/ai-dial-chat/blob/development/libs/shared/src/types/features.ts
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
@@ -154,7 +154,7 @@ vertexai:
       iam.gke.io/gcp-service-account: "%%GCP_VERTEXAI_SERVICE_ACCOUNT%%"
 
   env:
-    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
     GCP_PROJECT_ID: "%%GCP_PROJECT_ID%%"
     DEFAULT_REGION: "%%GCP_REGION%%"
 
@@ -162,7 +162,7 @@ bedrock:
   enabled: true
 
   env:
-    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
     AWS_ACCESS_KEY_ID: "%%AWS_ACCESS_KEY%%"
     AWS_SECRET_ACCESS_KEY: "%%AWS_SECRET_KEY%%"
     AWS_DEFAULT_REGION: "%%AWS_BEDROCK_REGION%%"
@@ -174,7 +174,7 @@ openai:
   enabled: true
 
   env:
-    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
 
   podLabels:
     azure.workload.identity/use: "true"

--- a/charts/dial/examples/gcp/simple/README.md
+++ b/charts/dial/examples/gcp/simple/README.md
@@ -17,7 +17,7 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [workload identity federation for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) installed and configured
 - [Google Storage bucket](https://cloud.google.com/storage/docs/buckets)
-- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `anthropic.claude-opus-4-8` model deployed:
+- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `global.anthropic.claude-opus-4-8` model deployed:
   - [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/gcp/simple/README.md
+++ b/charts/dial/examples/gcp/simple/README.md
@@ -18,7 +18,7 @@
 - [workload identity federation for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) installed and configured
 - [Google Storage bucket](https://cloud.google.com/storage/docs/buckets)
 - [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-3.5-flash` model deployed:
-- [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
+  - [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 
 ## Expected Outcome
 

--- a/charts/dial/examples/gcp/simple/README.md
+++ b/charts/dial/examples/gcp/simple/README.md
@@ -11,9 +11,7 @@
 
 - GKE 1.24+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
-- [Gateway API CRD](https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-a-gateway-controller) installed in the cluster
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
-- [Ingress-Traefik Controller](https://doc.traefik.io/traefik/setup/kubernetes/) installed in the cluster
 - [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (optional)
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [workload identity federation for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) installed and configured

--- a/charts/dial/examples/gcp/simple/README.md
+++ b/charts/dial/examples/gcp/simple/README.md
@@ -17,7 +17,7 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [workload identity federation for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) installed and configured
 - [Google Storage bucket](https://cloud.google.com/storage/docs/buckets)
-- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-chat-latest` model deployed:
+- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `anthropic.claude-opus-4-8` model deployed:
   - [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/gcp/simple/README.md
+++ b/charts/dial/examples/gcp/simple/README.md
@@ -17,7 +17,7 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [workload identity federation for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) installed and configured
 - [Google Storage bucket](https://cloud.google.com/storage/docs/buckets)
-- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-2.5-pro` model deployed:
+- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-chat-latest` model deployed:
   - [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/gcp/simple/README.md
+++ b/charts/dial/examples/gcp/simple/README.md
@@ -12,6 +12,7 @@
 - GKE 1.24+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
+- [Ingress-Nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/) installed in the cluster
 - [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (optional)
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [workload identity federation for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) installed and configured

--- a/charts/dial/examples/gcp/simple/README.md
+++ b/charts/dial/examples/gcp/simple/README.md
@@ -11,7 +11,7 @@
 
 - GKE 1.24+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
-- [Gateway API CRD](https://gateway-api.sigs.k8s.io/docs/concepts/api-overview/) installed in the cluster
+- [Gateway API CRD](https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-a-gateway-controller) installed in the cluster
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
 - [Ingress-Traefik Controller](https://doc.traefik.io/traefik/setup/kubernetes/) installed in the cluster
 - [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (optional)

--- a/charts/dial/examples/gcp/simple/README.md
+++ b/charts/dial/examples/gcp/simple/README.md
@@ -69,7 +69,6 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%GCP_REGION%%` with GCP Region e.g. `us-east1`
     - Replace `%%GCP_VERTEXAI_SERVICE_ACCOUNT%%` with Google Service Account from [prerequisites](#prerequisites)
     - It's assumed you've configured **external-dns** and **cert-manager** beforehand, so replace `%%CLUSTER_ISSUER%%` with your cluster issuer name, e.g. `letsencrypt-production`
-    - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
 1. Install `dial` helm chart in created namespace, applying custom values file:
 

--- a/charts/dial/examples/gcp/simple/README.md
+++ b/charts/dial/examples/gcp/simple/README.md
@@ -70,6 +70,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%GCP_REGION%%` with GCP Region e.g. `us-east1`
     - Replace `%%GCP_VERTEXAI_SERVICE_ACCOUNT%%` with Google Service Account from [prerequisites](#prerequisites)
     - It's assumed you've configured **external-dns** and **cert-manager** beforehand, so replace `%%CLUSTER_ISSUER%%` with your cluster issuer name, e.g. `letsencrypt-production`
+    - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
 1. Install `dial` helm chart in created namespace, applying custom values file:
 

--- a/charts/dial/examples/gcp/simple/README.md
+++ b/charts/dial/examples/gcp/simple/README.md
@@ -17,7 +17,7 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [workload identity federation for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) installed and configured
 - [Google Storage bucket](https://cloud.google.com/storage/docs/buckets)
-- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-pro` model deployed:
+- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-2.5-pro` model deployed:
   - [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/gcp/simple/README.md
+++ b/charts/dial/examples/gcp/simple/README.md
@@ -17,7 +17,7 @@
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [workload identity federation for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) installed and configured
 - [Google Storage bucket](https://cloud.google.com/storage/docs/buckets)
-- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `global.anthropic.claude-opus-4-8` model deployed:
+- [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `gemini-3.5-flash` model deployed:
 - [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 
 ## Expected Outcome

--- a/charts/dial/examples/gcp/simple/README.md
+++ b/charts/dial/examples/gcp/simple/README.md
@@ -11,8 +11,9 @@
 
 - GKE 1.24+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
+- [Gateway API CRD](https://gateway-api.sigs.k8s.io/docs/concepts/api-overview/) installed in the cluster
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
-- [Ingress-Nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/) installed in the cluster
+- [Ingress-Traefik Controller](https://doc.traefik.io/traefik/setup/kubernetes/) installed in the cluster
 - [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (optional)
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [workload identity federation for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) installed and configured

--- a/charts/dial/examples/gcp/simple/README.md
+++ b/charts/dial/examples/gcp/simple/README.md
@@ -18,7 +18,7 @@
 - [workload identity federation for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) installed and configured
 - [Google Storage bucket](https://cloud.google.com/storage/docs/buckets)
 - [Google Vertex AI](https://cloud.google.com/vertex-ai/?hl=en) `global.anthropic.claude-opus-4-8` model deployed:
-  - [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
+- [GCP Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/vertex-model-deployment)
 
 ## Expected Outcome
 

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -25,11 +25,11 @@ core:
     aidial.config.json: |
       {
         "models": {
-          "gemini-2.5-pro": {
+          "gemini-chat-latest": {
             "type": "chat",
-            "displayName": "Gemini Pro 2.5 Pro",
+            "displayName": "Google (Gemini)",
             "iconUrl": "https://dial.%%DOMAIN%%/themes/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-2.5-pro/chat/completions"
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-chat-latest/chat/completions"
           }
         },
         "keys": {
@@ -41,7 +41,7 @@ core:
         "roles": {
           "chat": {
             "limits": {
-              "gemini-2.5-pro": {}
+              "gemini-chat-latest": {}
             }
           }
         }

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -75,7 +75,7 @@ core:
           password: "%%REDIS_PASSWORD%%"
   ingress:
     enabled: true
-    ingressClassName: traefik
+    ingressClassName: nginx
     annotations:
       cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%" # To issue ssl certificate
     hosts:
@@ -108,7 +108,7 @@ chat:
 
   ingress:
     enabled: true
-    ingressClassName: traefik
+    ingressClassName: nginx
     annotations:
       cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%" # To issue ssl certificate
     hosts:

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -72,7 +72,6 @@ core:
       aclUsers:
         default:
           password: "%%REDIS_PASSWORD%%"
-
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -120,14 +119,19 @@ chat:
 
 themes:
   enabled: true
-  httpRoute:
+  ingress:
     enabled: true
-    parentRefs:
-      - name: traefik
-        namespace: traefik
-        sectionName: websecure
-    hostnames:
-      - themes.%%DOMAIN%%
+    ingressClassName: nginx
+    path: "/themes/(.*)"
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: "/$1"
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
+    hosts:
+      - dial.%%DOMAIN%%
+    tls:
+      - secretName: "dial-tls-secret"
+        hosts:
+          - dial.%%DOMAIN%%
 
 vertexai:
   enabled: true

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -24,19 +24,20 @@ core:
   secrets:
     aidial.config.json: |
       {
-        models: {
+        "models": {
           "gemini-3.5-flash": {
-          "type": "chat",
-          "displayName": "Google (Gemini)",
-          "iconUrl": "/Gemini.svg",
-          "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions",
-          "upstreams": [
-            {
-              "extraData": {
-                "region": "global"
+            "type": "chat",
+            "displayName": "Google (Gemini)",
+            "iconUrl": "/Gemini.svg",
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions",
+            "upstreams": [
+              {
+                "extraData": {
+                  "region": "global"
+                }
               }
-            }
-          ]
+            ]
+          }
         },
         "keys": {
           "%%DIAL_API_KEY%%": {

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -71,7 +71,6 @@ core:
       enabled: true
       aclUsers:
         default:
-          permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
   ingress:
     enabled: true

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -75,13 +75,13 @@ core:
 
   ingress:
     enabled: true
-    ingressClassName: nginx
+    ingressClassName: traefik
     annotations:
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%" # To issue ssl certificate
     hosts:
       - dial.%%DOMAIN%%
     tls:
-      - secretName: "dial-tls-secret"
+      - secretName: "dial-tls"
         hosts:
           - dial.%%DOMAIN%%
 
@@ -93,7 +93,7 @@ chat:
     NEXTAUTH_URL: "https://chat.%%DOMAIN%%"
     # -- DIAL core API endpoint
     # Internal service name (DNS name) of DIAL core service
-    DIAL_API_HOST: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_API_HOST: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
     # -- List of DIAL chat features to enable;
     # ref: https://github.com/epam/ai-dial-chat/blob/development/libs/shared/src/types/features.ts
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
@@ -105,33 +105,29 @@ chat:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
     # -- API key defined in core configuration
     DIAL_API_KEY: "%%DIAL_API_KEY%%"
+
   ingress:
     enabled: true
-    ingressClassName: nginx
+    ingressClassName: traefik
     annotations:
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%" # To issue ssl certificate
     hosts:
       - chat.%%DOMAIN%%
     tls:
-      - secretName: "chat-tls-secret"
+      - secretName: "chat-tls"
         hosts:
           - chat.%%DOMAIN%%
 
 themes:
   enabled: true
-  ingress:
+  httpRoute:
     enabled: true
-    ingressClassName: nginx
-    path: "/themes/(.*)"
-    annotations:
-      nginx.ingress.kubernetes.io/rewrite-target: "/$1"
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
-    hosts:
-      - dial.%%DOMAIN%%
-    tls:
-      - secretName: "dial-tls-secret"
-        hosts:
-          - dial.%%DOMAIN%%
+    parentRefs:
+      - name: traefik
+        namespace: traefik
+        sectionName: websecure
+    hostnames:
+      - themes.%%DOMAIN%%
 
 vertexai:
   enabled: true
@@ -143,6 +139,6 @@ vertexai:
       iam.gke.io/gcp-service-account: "%%GCP_VERTEXAI_SERVICE_ACCOUNT%%"
 
   env:
-    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
     GCP_PROJECT_ID: "%%GCP_PROJECT_ID%%"
     DEFAULT_REGION: "%%GCP_REGION%%"

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -28,7 +28,7 @@ core:
           "gemini-3.5-flash": {
             "type": "chat",
             "displayName": "Google (Gemini)",
-            "iconUrl": "/Gemini.svg",
+            "iconUrl": "Gemini.svg",
             "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions",
             "upstreams": [
               {
@@ -99,7 +99,7 @@ chat:
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
     # -- External or Internal URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
-    THEMES_CONFIG_HOST: "https://%%THEMES_CONFIG_HOST%%"
+    THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
     DEFAULT_MODEL: "gemini-3.5-flash"
   secrets:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
@@ -120,19 +120,6 @@ chat:
 
 themes:
   enabled: true
-  ingress:
-    enabled: true
-    ingressClassName: nginx
-    path: "/themes/(.*)"
-    annotations:
-      nginx.ingress.kubernetes.io/rewrite-target: "/$1"
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
-    hosts:
-      - dial.%%DOMAIN%%
-    tls:
-      - secretName: "dial-tls-secret"
-        hosts:
-          - dial.%%DOMAIN%%
 
 vertexai:
   enabled: true

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -25,11 +25,11 @@ core:
     aidial.config.json: |
       {
         "models": {
-          "gemini-pro": {
+          "gemini-2.5-pro": {
             "type": "chat",
-            "displayName": "Gemini Pro",
+            "displayName": "Gemini Pro 2.5 Pro",
             "iconUrl": "https://dial.%%DOMAIN%%/themes/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-pro/chat/completions"
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-2.5-pro/chat/completions"
           }
         },
         "keys": {
@@ -41,7 +41,7 @@ core:
         "roles": {
           "chat": {
             "limits": {
-              "gemini-pro": {}
+              "gemini-2.5-pro": {}
             }
           }
         }
@@ -58,9 +58,13 @@ core:
       mountPath: "/mnt/secrets-store/aidial.config.json"
       subPath: aidial.config.json
       readOnly: true
-  redis:
+  valkey:
     enabled: true
-    password: "%%REDIS_PASSWORD%%"
+    auth:
+      enabled: true
+      aclUsers:
+        default:
+          password: "%%REDIS_PASSWORD%%"
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -24,13 +24,20 @@ core:
   secrets:
     aidial.config.json: |
       {
-        "models": {
+        models: {
           "gemini-3.5-flash": {
             "type": "chat",
             "displayName": "Google (Gemini)",
-            "iconUrl": "https://dial.%%DOMAIN%%/themes/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions"
-          }
+            "iconUrl": "/Gemini.svg",
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions",
+            "upstreams": [
+              {
+                "extraData": {
+                  "region": "global"
+                }
+              }
+            ],
+          },
         },
         "keys": {
           "%%DIAL_API_KEY%%": {

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -64,6 +64,7 @@ core:
       enabled: true
       aclUsers:
         default:
+          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
   ingress:
     enabled: true

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -71,6 +71,7 @@ core:
       enabled: true
       aclUsers:
         default:
+          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
   ingress:
     enabled: true

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -81,7 +81,7 @@ core:
     hosts:
       - dial.%%DOMAIN%%
     tls:
-      - secretName: "dial-tls"
+      - secretName: "dial-tls-secret"
         hosts:
           - dial.%%DOMAIN%%
 
@@ -114,7 +114,7 @@ chat:
     hosts:
       - chat.%%DOMAIN%%
     tls:
-      - secretName: "chat-tls"
+      - secretName: "chat-tls-secret"
         hosts:
           - chat.%%DOMAIN%%
 

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -26,18 +26,17 @@ core:
       {
         models: {
           "gemini-3.5-flash": {
-            "type": "chat",
-            "displayName": "Google (Gemini)",
-            "iconUrl": "/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions",
-            "upstreams": [
-              {
-                "extraData": {
-                  "region": "global"
-                }
+          "type": "chat",
+          "displayName": "Google (Gemini)",
+          "iconUrl": "/Gemini.svg",
+          "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions",
+          "upstreams": [
+            {
+              "extraData": {
+                "region": "global"
               }
-            ],
-          },
+            }
+          ]
         },
         "keys": {
           "%%DIAL_API_KEY%%": {

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -71,7 +71,7 @@ core:
       enabled: true
       aclUsers:
         default:
-          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
+          permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
   ingress:
     enabled: true

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -71,8 +71,8 @@ core:
       enabled: true
       aclUsers:
         default:
-          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
+
   ingress:
     enabled: true
     ingressClassName: nginx
@@ -93,13 +93,14 @@ chat:
     NEXTAUTH_URL: "https://chat.%%DOMAIN%%"
     # -- DIAL core API endpoint
     # Internal service name (DNS name) of DIAL core service
-    DIAL_API_HOST: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_API_HOST: "http://core.%%NAMESPACE%%.svc.cluster.local"
     # -- List of DIAL chat features to enable;
     # ref: https://github.com/epam/ai-dial-chat/blob/development/libs/shared/src/types/features.ts
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
-    # -- External URL of DIAL themes;
+    # -- External or Internal URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
-    THEMES_CONFIG_HOST: "https://dial.%%DOMAIN%%/themes"
+    THEMES_CONFIG_HOST: "https://%%THEMES_CONFIG_HOST%%"
+    DEFAULT_MODEL: "gemini-3.5-flash"
   secrets:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
     # -- API key defined in core configuration
@@ -142,6 +143,6 @@ vertexai:
       iam.gke.io/gcp-service-account: "%%GCP_VERTEXAI_SERVICE_ACCOUNT%%"
 
   env:
-    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_URL: "http://core.%%NAMESPACE%%.svc.cluster.local"
     GCP_PROJECT_ID: "%%GCP_PROJECT_ID%%"
     DEFAULT_REGION: "%%GCP_REGION%%"

--- a/charts/dial/examples/gcp/simple/values.yaml
+++ b/charts/dial/examples/gcp/simple/values.yaml
@@ -25,11 +25,11 @@ core:
     aidial.config.json: |
       {
         "models": {
-          "gemini-chat-latest": {
+          "gemini-3.5-flash": {
             "type": "chat",
             "displayName": "Google (Gemini)",
             "iconUrl": "https://dial.%%DOMAIN%%/themes/Gemini.svg",
-            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-chat-latest/chat/completions"
+            "endpoint": "http://dial-vertexai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gemini-3.5-flash/chat/completions"
           }
         },
         "keys": {
@@ -41,7 +41,7 @@ core:
         "roles": {
           "chat": {
             "limits": {
-              "gemini-chat-latest": {}
+              "gemini-3.5-flash": {}
             }
           }
         }

--- a/charts/dial/examples/generic/simple/README.md
+++ b/charts/dial/examples/generic/simple/README.md
@@ -11,7 +11,6 @@
 
 - Kubernetes cluster 1.24+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
-- [Gateway API CRD](https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-a-gateway-controller) installed in the cluster
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
 - [Ingress-Nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/) installed in the cluster
 - [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (optional)

--- a/charts/dial/examples/generic/simple/README.md
+++ b/charts/dial/examples/generic/simple/README.md
@@ -15,7 +15,7 @@
 - [Ingress-Nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/) installed in the cluster
 - [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (optional)
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
-- [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview) `gpt-35-turbo` model deployed:
+- [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview) `gpt-5-2025-08-07` model deployed:
   - [Azure Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/openai-model-deployment)
 
 ## Expected Outcome
@@ -63,7 +63,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
-    - Replace `%%AZURE_MODEL_ENDPOINT%%` with Azure OpenAI Model Endpoint from [prerequisites](#prerequisites), e.g. `https://not-a-real-endpoint.openai.azure.com/openai/deployments/gpt-35-turbo/chat/completions`
+    - Replace `%%AZURE_MODEL_ENDPOINT%%` with Azure OpenAI Model Endpoint from [prerequisites](#prerequisites), e.g. `https://not-a-real-endpoint.openai.azure.com/openai/deployments/gpt-5-2025-08-07/chat/completions`
     - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - It's assumed you've configured **external-dns** and **cert-manager** beforehand, so replace `%%CLUSTER_ISSUER%%` with your cluster issuer name, e.g. `letsencrypt-production`
 

--- a/charts/dial/examples/generic/simple/README.md
+++ b/charts/dial/examples/generic/simple/README.md
@@ -20,9 +20,9 @@
 
 ## Expected Outcome
 
-By following the instructions in this guide, you will successfully install the AI DIAL system with configured connection to the Azure GPT-gpt-chat-latest API.\
-Please note that this guide **does not use a persistent disk** for data storage.\
-Please note that this guide represents a very basic deployment scenario, and **should never be used in production**.\
+By following the instructions in this guide, you will successfully install the AI DIAL system with configured connection to the Azure gpt-chat-latest API.
+Please note that this guide **does not use a persistent disk** for data storage.
+Please note that this guide represents a very basic deployment scenario, and **should never be used in production**.
 Configuring authentication provider, encrypted secrets, model usage limits, Ingress allowlisting and other security measures are **out of scope** of this guide.
 
 ## Install
@@ -63,7 +63,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
-    - Replace `%%AZURE_MODEL_ENDPOINT%%` with Azure OpenAI Model Endpoint from [prerequisites](#prerequisites), e.g. `https://not-a-real-endpoint.openai.azure.com/openai/deployments/gpt-chat-latest/chat/completions`
+    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `https://not-a-real-endpoint.openai.azure.com/openai/v1/responses`
     - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - It's assumed you've configured **external-dns** and **cert-manager** beforehand, so replace `%%CLUSTER_ISSUER%%` with your cluster issuer name, e.g. `letsencrypt-production`
 

--- a/charts/dial/examples/generic/simple/README.md
+++ b/charts/dial/examples/generic/simple/README.md
@@ -11,7 +11,7 @@
 
 - Kubernetes cluster 1.24+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
-- [Gateway API CRD](https://gateway-api.sigs.k8s.io/docs/concepts/api-overview/) installed in the cluster
+- [Gateway API CRD](https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-a-gateway-controller) installed in the cluster
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
 - [Ingress-Traefik Controller](https://doc.traefik.io/traefik/setup/kubernetes/) installed in the cluster
 - [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (optional)

--- a/charts/dial/examples/generic/simple/README.md
+++ b/charts/dial/examples/generic/simple/README.md
@@ -15,12 +15,12 @@
 - [Ingress-Nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/) installed in the cluster
 - [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (optional)
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
-- [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview) `gpt-5-2025-08-07` model deployed:
+- [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview) `gpt-chat-latest` model deployed:
   - [Azure Model Deployment Guide](https://docs.dialx.ai/tutorials/devops/deployment/deployment-of-models/openai-model-deployment)
 
 ## Expected Outcome
 
-By following the instructions in this guide, you will successfully install the AI DIAL system with configured connection to the Azure GPT-3.5 API.\
+By following the instructions in this guide, you will successfully install the AI DIAL system with configured connection to the Azure GPT-gpt-chat-latest API.\
 Please note that this guide **does not use a persistent disk** for data storage.\
 Please note that this guide represents a very basic deployment scenario, and **should never be used in production**.\
 Configuring authentication provider, encrypted secrets, model usage limits, Ingress allowlisting and other security measures are **out of scope** of this guide.
@@ -63,7 +63,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
-    - Replace `%%AZURE_MODEL_ENDPOINT%%` with Azure OpenAI Model Endpoint from [prerequisites](#prerequisites), e.g. `https://not-a-real-endpoint.openai.azure.com/openai/deployments/gpt-5-2025-08-07/chat/completions`
+    - Replace `%%AZURE_MODEL_ENDPOINT%%` with Azure OpenAI Model Endpoint from [prerequisites](#prerequisites), e.g. `https://not-a-real-endpoint.openai.azure.com/openai/deployments/gpt-chat-latest/chat/completions`
     - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - It's assumed you've configured **external-dns** and **cert-manager** beforehand, so replace `%%CLUSTER_ISSUER%%` with your cluster issuer name, e.g. `letsencrypt-production`
 

--- a/charts/dial/examples/generic/simple/README.md
+++ b/charts/dial/examples/generic/simple/README.md
@@ -13,7 +13,7 @@
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
 - [Gateway API CRD](https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-a-gateway-controller) installed in the cluster
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
-- [Ingress-Traefik Controller](https://doc.traefik.io/traefik/setup/kubernetes/) installed in the cluster
+- [Ingress-Nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/) installed in the cluster
 - [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (optional)
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview) `gpt-chat-latest` model deployed:

--- a/charts/dial/examples/generic/simple/README.md
+++ b/charts/dial/examples/generic/simple/README.md
@@ -11,8 +11,9 @@
 
 - Kubernetes cluster 1.24+
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured
+- [Gateway API CRD](https://gateway-api.sigs.k8s.io/docs/concepts/api-overview/) installed in the cluster
 - [Helm](https://helm.sh/docs/intro/install/) `3.8.0+` installed
-- [Ingress-Nginx Controller](https://kubernetes.github.io/ingress-nginx/deploy/) installed in the cluster
+- [Ingress-Traefik Controller](https://doc.traefik.io/traefik/setup/kubernetes/) installed in the cluster
 - [cert-manager](https://cert-manager.io/docs/installation/) installed in the cluster (optional)
 - [external-dns](https://github.com/kubernetes-sigs/external-dns) installed in the cluster (optional)
 - [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview) `gpt-chat-latest` model deployed:

--- a/charts/dial/examples/generic/simple/README.md
+++ b/charts/dial/examples/generic/simple/README.md
@@ -65,6 +65,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
     - It's assumed you've configured **external-dns** and **cert-manager** beforehand, so replace `%%CLUSTER_ISSUER%%` with your cluster issuer name, e.g. `letsencrypt-production`
+    - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
 1. Install `dial` helm chart in created namespace, applying custom values file:
 

--- a/charts/dial/examples/generic/simple/README.md
+++ b/charts/dial/examples/generic/simple/README.md
@@ -66,7 +66,6 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
     - It's assumed you've configured **external-dns** and **cert-manager** beforehand, so replace `%%CLUSTER_ISSUER%%` with your cluster issuer name, e.g. `letsencrypt-production`
-    - Replace `%%THEMES_CONFIG_HOST%%` - with the host URL for a custom themes configuration. Can lead to public and private resource.
 
 1. Install `dial` helm chart in created namespace, applying custom values file:
 

--- a/charts/dial/examples/generic/simple/README.md
+++ b/charts/dial/examples/generic/simple/README.md
@@ -63,7 +63,7 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%CORE_ENCRYPT_KEY%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
-    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `https://not-a-real-endpoint.openai.azure.com/openai/v1/responses`
+    - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
     - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - It's assumed you've configured **external-dns** and **cert-manager** beforehand, so replace `%%CLUSTER_ISSUER%%` with your cluster issuer name, e.g. `letsencrypt-production`
 

--- a/charts/dial/examples/generic/simple/README.md
+++ b/charts/dial/examples/generic/simple/README.md
@@ -64,7 +64,6 @@ Configuring authentication provider, encrypted secrets, model usage limits, Ingr
     - Replace `%%NEXTAUTH_SECRET%%` with generated value (`openssl rand -base64 64`)
     - Replace `%%REDIS_PASSWORD%%` with generated value (`pwgen -s -1 32`)
     - Replace `%%AZURE_DEPLOYMENT_HOST%%` with Azure OpenAI endpoint host from prerequisites, e.g. `not-a-real-endpoint.openai.azure.com`
-    - Replace `%%AZURE_MODEL_KEY%%` with Azure OpenAI Model Key from [prerequisites](#prerequisites), e.g. `3F0UZREXNOTAREALKEYDCvzSkznPFa`
     - It's assumed you've configured **external-dns** and **cert-manager** beforehand, so replace `%%CLUSTER_ISSUER%%` with your cluster issuer name, e.g. `letsencrypt-production`
 
 1. Install `dial` helm chart in created namespace, applying custom values file:

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -65,13 +65,13 @@ core:
 
   ingress:
     enabled: true
-    ingressClassName: nginx
+    ingressClassName: traefik
     annotations:
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%" # To issue ssl certificate
     hosts:
       - dial.%%DOMAIN%%
     tls:
-      - secretName: "dial-tls-secret"
+      - secretName: "dial-tls"
         hosts:
           - dial.%%DOMAIN%%
 
@@ -83,7 +83,7 @@ chat:
     NEXTAUTH_URL: "https://chat.%%DOMAIN%%"
     # -- DIAL core API endpoint
     # Internal service name (DNS name) of DIAL core service
-    DIAL_API_HOST: "http://core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_API_HOST: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
     # -- List of DIAL chat features to enable;
     # ref: https://github.com/epam/ai-dial-chat/blob/development/libs/shared/src/types/features.ts
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
@@ -95,22 +95,29 @@ chat:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
     # -- API key defined in core configuration
     DIAL_API_KEY: "%%DIAL_API_KEY%%"
+
   ingress:
     enabled: true
-    ingressClassName: nginx
+    ingressClassName: traefik
     annotations:
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%" # To issue ssl certificate
     hosts:
       - chat.%%DOMAIN%%
     tls:
-      - secretName: "chat-tls-secret"
+      - secretName: "chat-tls"
         hosts:
           - chat.%%DOMAIN%%
 
 themes:
   enabled: true
-  ingress:
-    enabled: false
+  httpRoute:
+    enabled: true
+    parentRefs:
+      - name: traefik
+        namespace: traefik
+        sectionName: websecure
+    hostnames:
+      - themes.%%DOMAIN%%
 
 openai:
   enabled: true

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -61,7 +61,7 @@ core:
       enabled: true
       aclUsers:
         default:
-          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
+          permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
   ingress:
     enabled: true

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -62,18 +62,8 @@ core:
       aclUsers:
         default:
           password: "%%REDIS_PASSWORD%%"
-
   ingress:
-    enabled: true
-    ingressClassName: traefik
-    annotations:
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%" # To issue ssl certificate
-    hosts:
-      - dial.%%DOMAIN%%
-    tls:
-      - secretName: "dial-tls"
-        hosts:
-          - dial.%%DOMAIN%%
+    enabled: false
 
 chat:
   enabled: true
@@ -95,29 +85,33 @@ chat:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
     # -- API key defined in core configuration
     DIAL_API_KEY: "%%DIAL_API_KEY%%"
-
   ingress:
     enabled: true
-    ingressClassName: traefik
+    ingressClassName: nginx
     annotations:
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%" # To issue ssl certificate
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
     hosts:
       - chat.%%DOMAIN%%
     tls:
-      - secretName: "chat-tls"
+      - secretName: "chat-tls-secret"
         hosts:
           - chat.%%DOMAIN%%
 
 themes:
   enabled: true
-  httpRoute:
+  ingress:
     enabled: true
-    parentRefs:
-      - name: traefik
-        namespace: traefik
-        sectionName: websecure
-    hostnames:
-      - themes.%%DOMAIN%%
+    ingressClassName: nginx
+    path: "/themes/(.*)"
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: "/$1"
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
+    hosts:
+      - dial.%%DOMAIN%%
+    tls:
+      - secretName: "dial-tls-secret"
+        hosts:
+          - dial.%%DOMAIN%%
 
 openai:
   enabled: true

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -80,7 +80,7 @@ chat:
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
     # -- External or Internal URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
-    THEMES_CONFIG_HOST: "https://%%THEMES_CONFIG_HOST%%"
+    THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
     DEFAULT_MODEL: "gpt-chat-latest"
   secrets:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
@@ -100,19 +100,6 @@ chat:
 
 themes:
   enabled: true
-  ingress:
-    enabled: true
-    ingressClassName: nginx
-    path: "/themes/(.*)"
-    annotations:
-      nginx.ingress.kubernetes.io/rewrite-target: "/$1"
-      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
-    hosts:
-      - dial.%%DOMAIN%%
-    tls:
-      - secretName: "dial-tls-secret"
-        hosts:
-          - dial.%%DOMAIN%%
 
 openai:
   enabled: true

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -16,11 +16,11 @@ core:
     aidial.config.json: |
       {
         "models": {
-          "gpt-35-turbo": {
+          "gpt-5-2025-08-07": {
             "type": "chat",
-            "displayName": "GPT-3.5",
-            "iconUrl": "gpt3.svg",
-            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-35-turbo/chat/completions",
+            "displayName": "GPT-5",
+            "iconUrl": "gpt5.svg",
+            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-5-2025-08-07/chat/completions",
             "upstreams": [
               {
                 "endpoint": "%%AZURE_MODEL_ENDPOINT%%",
@@ -38,7 +38,7 @@ core:
         "roles": {
           "chat": {
             "limits": {
-              "gpt-35-turbo": {}
+              "gpt-5-2025-08-07": {}
             }
           }
         }
@@ -55,9 +55,13 @@ core:
       mountPath: "/mnt/secrets-store/aidial.config.json"
       subPath: aidial.config.json
       readOnly: true
-  redis:
+  valkey:
     enabled: true
-    password: "%%REDIS_PASSWORD%%"
+    auth:
+      enabled: true
+      aclUsers:
+        default:
+          password: "%%REDIS_PASSWORD%%"
   ingress:
     enabled: false
 

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -16,11 +16,11 @@ core:
     aidial.config.json: |
       {
         "models": {
-          "gpt-5-2025-08-07": {
+          "gpt-chat-latest": {
             "type": "chat",
-            "displayName": "GPT-5",
-            "iconUrl": "gpt5.svg",
-            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-5-2025-08-07/chat/completions",
+            "displayName": "GPT Chat Latest",
+            "iconUrl": "./charts/dial/examples/gcp/complete/values.yaml",
+            "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
             "upstreams": [
               {
                 "endpoint": "%%AZURE_MODEL_ENDPOINT%%",
@@ -38,7 +38,7 @@ core:
         "roles": {
           "chat": {
             "limits": {
-              "gpt-5-2025-08-07": {}
+              "gpt-chat-latest": {}
             }
           }
         }

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -112,3 +112,6 @@ themes:
 
 openai:
   enabled: true
+
+  env:
+    DIAL_URL: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -61,7 +61,6 @@ core:
       enabled: true
       aclUsers:
         default:
-          permissions: "on ~* allchannels +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
   ingress:
     enabled: true

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -19,12 +19,11 @@ core:
           "gpt-chat-latest": {
             "type": "chat",
             "displayName": "GPT Chat Latest",
-            "iconUrl": "./charts/dial/examples/gcp/complete/values.yaml",
+            "iconUrl": "gpt4.svg",
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
             "upstreams": [
               {
-                "endpoint": "%%AZURE_MODEL_ENDPOINT%%",
-                "key": "%%AZURE_MODEL_KEY%%"
+                  "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
               }
             ]
           }

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -61,6 +61,7 @@ core:
       enabled: true
       aclUsers:
         default:
+          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
   ingress:
     enabled: false

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -64,7 +64,16 @@ core:
           permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
   ingress:
-    enabled: false
+    enabled: true
+    ingressClassName: nginx
+    annotations:
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
+    hosts:
+      - dial.%%DOMAIN%%
+    tls:
+      - secretName: "dial-tls-secret"
+        hosts:
+          - dial.%%DOMAIN%%
 
 chat:
   enabled: true

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -12,6 +12,7 @@ core:
     aidial.identityProviders.fake.jwksUrl: "http://fakeJwksUrl"
     aidial.identityProviders.fake.rolePath: "roles"
     aidial.identityProviders.fake.issuerPattern: "issuer"
+    aidial.storage.prefix: "core"
   secrets:
     aidial.config.json: |
       {
@@ -60,10 +61,19 @@ core:
       enabled: true
       aclUsers:
         default:
-          permissions: "on ~* allchannels +psync +replconf +@read +@write +ping +info +@hash +@list +@pubsub +@scripting +TIME"
           password: "%%REDIS_PASSWORD%%"
+
   ingress:
-    enabled: false
+    enabled: true
+    ingressClassName: nginx
+    annotations:
+      cert-manager.io/cluster-issuer: "%%CLUSTER_ISSUER%%"
+    hosts:
+      - dial.%%DOMAIN%%
+    tls:
+      - secretName: "dial-tls-secret"
+        hosts:
+          - dial.%%DOMAIN%%
 
 chat:
   enabled: true
@@ -73,13 +83,14 @@ chat:
     NEXTAUTH_URL: "https://chat.%%DOMAIN%%"
     # -- DIAL core API endpoint
     # Internal service name (DNS name) of DIAL core service
-    DIAL_API_HOST: "http://dial-core.%%NAMESPACE%%.svc.cluster.local"
+    DIAL_API_HOST: "http://core.%%NAMESPACE%%.svc.cluster.local"
     # -- List of DIAL chat features to enable;
     # ref: https://github.com/epam/ai-dial-chat/blob/development/libs/shared/src/types/features.ts
     ENABLED_FEATURES: "conversations-section,prompts-section,top-settings,top-clear-conversation,top-chat-info,top-chat-model-settings,empty-chat-settings,header,footer,likes,conversations-sharing,prompts-sharing,input-files,attachments-manager,conversations-publishing,prompts-publishing"
-    # -- External URL of DIAL themes;
+    # -- External or Internal URL of DIAL themes;
     # Same allowlist as for DIAL chat should be applied
-    THEMES_CONFIG_HOST: "http://dial-themes.%%NAMESPACE%%.svc.cluster.local"
+    THEMES_CONFIG_HOST: "https://%%THEMES_CONFIG_HOST%%"
+    DEFAULT_MODEL: "gpt-chat-latest"
   secrets:
     NEXTAUTH_SECRET: "%%NEXTAUTH_SECRET%%"
     # -- API key defined in core configuration

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -23,8 +23,7 @@ core:
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
             "upstreams": [
               {
-                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses",
-                "key": "%%AZURE_MODEL_KEY%%"
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
               }
             ]
           }

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -21,9 +21,19 @@ core:
             "displayName": "GPT Chat Latest",
             "iconUrl": "gpt4.svg",
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
+            "auth": {
+              "type": "bearer",
+              "apiKeyEnv": "%%AZURE_MODEL_KEY%%",
+              "header": "Authorization",
+              "prefix": "Bearer "
+            },
+            "provider": {
+              "name": "openai-compatible",
+              "requiresApiKey": true
+            },
             "upstreams": [
               {
-                  "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
               }
             ]
           }

--- a/charts/dial/examples/generic/simple/values.yaml
+++ b/charts/dial/examples/generic/simple/values.yaml
@@ -21,19 +21,10 @@ core:
             "displayName": "GPT Chat Latest",
             "iconUrl": "gpt4.svg",
             "endpoint": "http://dial-openai.%%NAMESPACE%%.svc.cluster.local/openai/deployments/gpt-chat-latest/chat/completions",
-            "auth": {
-              "type": "bearer",
-              "apiKeyEnv": "%%AZURE_MODEL_KEY%%",
-              "header": "Authorization",
-              "prefix": "Bearer "
-            },
-            "provider": {
-              "name": "openai-compatible",
-              "requiresApiKey": true
-            },
             "upstreams": [
               {
-                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses"
+                "endpoint": "https://%%AZURE_DEPLOYMENT_HOST%%/openai/v1/responses",
+                "key": "%%AZURE_MODEL_KEY%%"
               }
             ]
           }

--- a/charts/dial/values.yaml
+++ b/charts/dial/values.yaml
@@ -93,9 +93,7 @@ chat:
     httpGet:
       path: /api/health
     failureThreshold: 6
-
   resourcesPreset: small
-
   containerSecurityContext:
     readOnlyRootFilesystem: false  # Temporarily disabled due to migration to a new domain. Requires review and removal in the next version.
 
@@ -137,9 +135,7 @@ openai:
     enabled: true
   readinessProbe:
     enabled: true
-
   resourcesPreset: micro
-
   containerSecurityContext:
     readOnlyRootFilesystem: false  # Temporarily disabled due to migration to a new domain. Requires review and removal in the next version.
 
@@ -162,9 +158,7 @@ bedrock:
     enabled: true
   readinessProbe:
     enabled: true
-
   resourcesPreset: micro
-
   containerSecurityContext:
     readOnlyRootFilesystem: false  # Temporarily disabled due to migration to a new domain. Requires review and removal in the next version.
 
@@ -183,9 +177,7 @@ vertexai:
     enabled: true
   readinessProbe:
     enabled: true
-
   resourcesPreset: small
-
   containerSecurityContext:
     readOnlyRootFilesystem: false  # Temporarily disabled due to migration to a new domain. Requires review and removal in the next version.
 
@@ -204,8 +196,6 @@ dial:
     enabled: true
   readinessProbe:
     enabled: true
-
   resourcesPreset: micro
-
   containerSecurityContext:
     readOnlyRootFilesystem: false  # Temporarily disabled due to migration to a new domain. Requires review and removal in the next version.


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made here. -->
- Introduced Valkey as a replacement for Redis
- Updated `values.yaml` for the Kubernetes installations with Valkey instead of Redis
- The versions of the LLM models used in the examples for values.yaml have been updated

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
Using Valkey as a replacement for Redis requires manual steps, and a brief guide is provided in the README.md of the chart.

### Testing

<!-- Please explain what testing was done. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/)
- [x] `appVersion` bumped in `Chart.yaml` if it's `dial` chart and any application version changed
- [x] Variables are documented in the `values.yaml` and added to the `README.md` using [helm-docs](https://github.com/norwoodj/helm-docs)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
