### PR TITLE
feat(dial-admin): DIAL Admin release 0.17

### DIFF
--- a/charts/dial-admin/Chart.yaml
+++ b/charts/dial-admin/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: MachineLearning
   licenses: Apache-2.0
 apiVersion: v2
-appVersion: "0.18.1"
+appVersion: "0.19.0"
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts
@@ -36,4 +36,4 @@ maintainers:
 name: dial-admin
 sources:
   - https://github.com/epam/ai-dial-helm/tree/main/charts/dial-admin
-version: 0.16.2
+version: 0.17.0

--- a/charts/dial-admin/README.md
+++ b/charts/dial-admin/README.md
@@ -1,6 +1,6 @@
 # dial-admin
 
-![Version: 0.16.2](https://img.shields.io/badge/Version-0.16.2-informational?style=flat-square) ![AppVersion: 0.18.1](https://img.shields.io/badge/AppVersion-0.18.1-informational?style=flat-square)
+![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![AppVersion: 0.19.0](https://img.shields.io/badge/AppVersion-0.19.0-informational?style=flat-square)
 
 Helm chart for DIAL Admin
 
@@ -130,7 +130,7 @@ helm install my-release dial/dial-admin -f values.yaml
 | backend.image.pullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. [Documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) |
 | backend.image.registry | string | `"docker.io"` | Image registry |
 | backend.image.repository | string | `"epam/ai-dial-admin-backend"` | Image repository |
-| backend.image.tag | string | `"0.18.1"` | Image tag (immutable tags are recommended) |
+| backend.image.tag | string | `"0.19.0"` | Image tag (immutable tags are recommended) |
 | backend.initContainers | list | `[]` | Add additional init containers to the dial-admin backend pod(s) [Documentation](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) |
 | backend.lifecycleHooks | object | `{}` | for the dial-admin backend container(s) to automate configuration before or after startup |
 | backend.livenessProbe | object | [Documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes) | Liveness Probes configuration |
@@ -254,7 +254,7 @@ helm install my-release dial/dial-admin -f values.yaml
 | frontend.image.pullPolicy | string | `"Always"` | Frontend image pull policy |
 | frontend.image.registry | string | `"docker.io"` | Frontend image registry |
 | frontend.image.repository | string | `"epam/ai-dial-admin-frontend"` | Frontend image repository |
-| frontend.image.tag | string | `"0.18.1"` | Frontend image tag |
+| frontend.image.tag | string | `"0.19.0"` | Frontend image tag |
 | frontend.resourcesPreset | string | `"micro"` | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if `resources` is set (recommended for production). [Documentation](https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15) |
 | fullnameOverride | string | `""` | String to fully override common.names.fullname |
 | global.compatibility.openshift.adaptSecurityContext | string | `"disabled"` | Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation) |
@@ -280,7 +280,7 @@ helm install my-release dial/dial-admin -f values.yaml
 | manager.image | object | [Documentation](https://kubernetes.io/docs/concepts/containers/images/) | Section to configure the image. |
 | manager.image.registry | string | `"docker.io"` | Image registry |
 | manager.image.repository | string | `"epam/ai-dial-admin-deployment-manager-backend"` | Image repository |
-| manager.image.tag | string | `"0.18.1"` | Image tag (immutable tags are recommended) |
+| manager.image.tag | string | `"0.19.0"` | Image tag (immutable tags are recommended) |
 | manager.rbac.create | bool | `true` |  |
 | manager.resourcesPreset | string | `"small"` | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if `resources` is set (recommended for production). [Documentation](https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15) |
 | manager.serviceAccount.create | bool | `true` |  |
@@ -481,3 +481,8 @@ If `manager.enabled` is set to `true` and this is an upgrade from a previous ver
     ```console
     bash /docker-entrypoint-initdb.d/secret/create-multiple-dbs.sh
     ```
+
+### To 0.17.0
+
+> [!IMPORTANT]
+> If you use the Deployment Manager metrics functionality (`METRICS_SCRAPE_ENABLED`, including resource usage via `METRICS_SCRAPE_RESOURCE_USAGE_ENABLED`), a [metrics-server](https://github.com/kubernetes-sigs/metrics-server) must be installed in the cluster. Without it, resource metrics (`metrics.k8s.io`) requests from the Deployment Manager will fail.

--- a/charts/dial-admin/README.md.gotmpl
+++ b/charts/dial-admin/README.md.gotmpl
@@ -247,10 +247,5 @@ If `manager.enabled` is set to `true` and this is an upgrade from a previous ver
 
 ### To 0.17.0
 
-> [!NOTE]
-> New optional Evaluation Framework components (`evaluation-postgresql`, `evaluation-metrics`, `evaluation-backend`) are now included and disabled by default.
-
-To enable the Evaluation Framework, see [Evaluation Framework](#evaluation-framework).
-
 > [!IMPORTANT]
 > If you use the Deployment Manager metrics functionality (`METRICS_SCRAPE_ENABLED`, including resource usage via `METRICS_SCRAPE_RESOURCE_USAGE_ENABLED`), a [metrics-server](https://github.com/kubernetes-sigs/metrics-server) must be installed in the cluster. Without it, resource metrics (`metrics.k8s.io`) requests from the Deployment Manager will fail.

--- a/charts/dial-admin/README.md.gotmpl
+++ b/charts/dial-admin/README.md.gotmpl
@@ -244,3 +244,13 @@ If `manager.enabled` is set to `true` and this is an upgrade from a previous ver
     ```console
     bash /docker-entrypoint-initdb.d/secret/create-multiple-dbs.sh
     ```
+
+### To 0.17.0
+
+> [!NOTE]
+> New optional Evaluation Framework components (`evaluation-postgresql`, `evaluation-metrics`, `evaluation-backend`) are now included and disabled by default.
+
+To enable the Evaluation Framework, see [Evaluation Framework](#evaluation-framework).
+
+> [!IMPORTANT]
+> If you use the Deployment Manager metrics functionality (`METRICS_SCRAPE_ENABLED`, including resource usage via `METRICS_SCRAPE_RESOURCE_USAGE_ENABLED`), a [metrics-server](https://github.com/kubernetes-sigs/metrics-server) must be installed in the cluster. Without it, resource metrics (`metrics.k8s.io`) requests from the Deployment Manager will fail.

--- a/charts/dial-admin/templates/deployment-manager/rbac.yaml
+++ b/charts/dial-admin/templates/deployment-manager/rbac.yaml
@@ -43,7 +43,6 @@ rules:
     verbs:
       - get
       - create
-      - update
       - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/dial-admin/templates/deployment-manager/rbac.yaml
+++ b/charts/dial-admin/templates/deployment-manager/rbac.yaml
@@ -43,6 +43,7 @@ rules:
     verbs:
       - get
       - create
+      - update
       - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -113,10 +114,26 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods/proxy
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - "metrics.k8s.io"
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
       - secrets
     verbs:
       - get
       - create
+      - update
+      - patch
       - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -188,10 +205,26 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods/proxy
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - "metrics.k8s.io"
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
       - secrets
     verbs:
       - get
       - create
+      - update
+      - patch
       - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -263,10 +296,26 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods/proxy
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - "metrics.k8s.io"
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
       - secrets
     verbs:
       - get
       - create
+      - update
+      - patch
       - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/dial-admin/values.yaml
+++ b/charts/dial-admin/values.yaml
@@ -36,7 +36,7 @@ backend:
     # -- Image repository
     repository: epam/ai-dial-admin-backend
     # -- Image tag (immutable tags are recommended)
-    tag: 0.18.1
+    tag: 0.19.0
     # -- Image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
     digest: ""
     # -- Image pull policy
@@ -547,7 +547,7 @@ frontend:
     # -- Frontend image repository
     repository: epam/ai-dial-admin-frontend
     # -- Frontend image tag
-    tag: 0.18.1
+    tag: 0.19.0
     # -- Frontend image pull policy
     pullPolicy: Always
 
@@ -574,7 +574,7 @@ manager:
     # -- Image repository
     repository: epam/ai-dial-admin-deployment-manager-backend
     # -- Image tag (immutable tags are recommended)
-    tag: 0.18.1
+    tag: 0.19.0
 
   commonAnnotations: {}
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR here (You can reference an issue using #) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made here. -->
Bump of version of the following applications:

ai-dial-admin-backend: 0.18.1 => 0.19.0
ai-dial-admin-frontend: 0.18.1 => 0.19.0
ai-dial-admin-deployment-manager-backend: 0.18.1 => 0.19.0

Updated manager Role/ClusterRole permissions for Knative, NIM, and KServe deploy namespaces to match Deployment Manager infrastructure requirements from 0.18.0 / 0.19.0:

Added update and patch on secrets (required for auto-provisioned image pull secrets when AUTO_PULL_SECRET_ENABLED is enabled)
Added get/create on pods/proxy (required for Deployment Manager metrics scrape)
Added get/list on metrics.k8s.io/pods (required for resource usage metrics)
### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Testing

<!-- Please explain what testing was done. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/)
- [ ] `appVersion` bumped in `Chart.yaml` if it's `dial` chart and any application version changed
- [ ] Variables are documented in the `values.yaml` and added to the `README.md` using [helm-docs](https://github.com/norwoodj/helm-docs)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
